### PR TITLE
FEAT: Input, TextArea, Tab 컴포넌트 개발

### DIFF
--- a/src/assets/Icons/search.svg
+++ b/src/assets/Icons/search.svg
@@ -1,4 +1,4 @@
 <svg width="64" height="65" viewBox="0 0 64 65" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M29.3333 51.402C41.1154 51.402 50.6667 41.8508 50.6667 30.0687C50.6667 18.2866 41.1154 8.73535 29.3333 8.73535C17.5513 8.73535 8 18.2866 8 30.0687C8 41.8508 17.5513 51.402 29.3333 51.402Z" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M56.0014 56.7348L44.4014 45.1348" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M29.3333 51.402C41.1154 51.402 50.6667 41.8508 50.6667 30.0687C50.6667 18.2866 41.1154 8.73535 29.3333 8.73535C17.5513 8.73535 8 18.2866 8 30.0687C8 41.8508 17.5513 51.402 29.3333 51.402Z" stroke="currentColor" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M56.0014 56.7348L44.4014 45.1348" stroke="currentColor" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,36 @@
+interface InputProps {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  type?: string;
+  width?: string;
+  //height?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+const Input = ({
+  value,
+  defaultValue,
+  onChange,
+  placeholder,
+  type = "text",
+  width,
+  className,
+  disabled = false,
+}: InputProps) => {
+  return (
+    <input
+      type={type}
+      value={value}
+      defaultValue={defaultValue}
+      onChange={onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={`px-4 py-5 text-base text-black leading-[135%] tracking-[-0.56px] gray-placeholder bg-white border border-[#E5E7EB] rounded-lg ${width} ${className}`}
+    />
+  );
+};
+
+export default Input;

--- a/src/components/Input/SearchInput.tsx
+++ b/src/components/Input/SearchInput.tsx
@@ -1,0 +1,43 @@
+import { Search } from "@/assets/Icons";
+import React from "react";
+
+interface SearchInputProps {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  width?: string;
+}
+
+const SearchInput = ({
+  value,
+  defaultValue,
+  onChange,
+  placeholder,
+  className = "",
+  disabled = false,
+  width = "w-full",
+}: SearchInputProps) => {
+  return (
+    <div
+      className={`flex items-center gap-2 py-5 px-4 text-base leading-[135%] tracking-[-0.56px] bg-white border border-[#E5E7EB] rounded-lg ${width} ${
+        disabled ? "opacity-50 cursor-not-allowed" : ""
+      } ${className}`}
+    >
+      <Search className="w-5 h-5 text-[#9DA3AE]" />
+      <input
+        type="text"
+        value={value}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="w-full text-black placeholder-gray-400 bg-transparent border-none focus:outline-none"
+      />
+    </div>
+  );
+};
+
+export default SearchInput;

--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -1,0 +1,37 @@
+interface TextAreaProps {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  width?: string;
+  height?: string;
+  maxLength?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+const TextArea = ({
+  value,
+  defaultValue,
+  onChange,
+  placeholder,
+  width,
+  height,
+  maxLength,
+  disabled = false,
+  className,
+}: TextAreaProps) => {
+  return (
+    <textarea
+      value={value}
+      defaultValue={defaultValue}
+      onChange={onChange}
+      placeholder={placeholder}
+      maxLength={maxLength}
+      disabled={disabled}
+      className={`px-4 py-5 text-base text-black leading-[135%] tracking-[-0.56px] gray-placeholder bg-white border border-[#E5E7EB] rounded-lg ${width} ${height} ${className}`}
+    />
+  );
+};
+
+export default TextArea;

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,0 +1,44 @@
+interface InputProps {
+  categories: string[];
+  active?: string;
+  onChange: (value: string) => void;
+  className?: string;
+  fitWidth?: boolean; //회색 border를 fit하게 맞출지의 유무
+  centerType?: boolean; //center로 오는 경우
+}
+
+const Tab = ({
+  categories,
+  active,
+  onChange,
+  className,
+  fitWidth = false,
+  centerType = false,
+}: InputProps) => {
+  const current = active ?? categories[0];
+  return (
+    <div
+      className={`relative flex flex-row gap-6  leading-[135%] tracking-[-0.56px] border-b border-[#E5E7EB]
+        ${fitWidth && "w-fit"} 
+        ${centerType && "justify-center"} ${className}`}
+    >
+      {categories.map((text) => (
+        <div
+          key={text}
+          className={`relative px-1 pb-4 text-base font-bold cursor-pointer
+            ${current === text ? "text-[#255FF4]" : "text-[#6C727F]"}
+            ${centerType && "px-26"}
+          `}
+          onClick={() => onChange(text)}
+        >
+          {text}
+          {current === text && (
+            <div className="absolute bottom-0 left-0 w-full h-[2px] bg-[#255FF4] translate-y-[1px]" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Tab;

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,13 @@
   padding: 0;
   box-sizing: border-box;
 }
+
+input:focus,
+textarea:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.gray-placeholder::placeholder {
+  color: rgba(57, 65, 80, 0.37);
+}


### PR DESCRIPTION
1. tab 
회색 border의 width가 fit 하게 맞는 경우와, 전체 width를 차지하는 경우 / tab 컴포넌트가 center에 위치하는 경우
총 3가지의 경우를 나누어 개발하였습니다.

![스크린샷 2025-05-28 213009](https://github.com/user-attachments/assets/29d71a50-a5ba-41ff-a984-9e6bb4f2a187)


3. Input 및 TextArea
 searchInput 관련하여서는 Icon 이 추가되어 별도의 SearchInput으로 컴포넌트 개발하였습니다.

![스크린샷 2025-05-28 213606](https://github.com/user-attachments/assets/8efe1976-963e-463e-8d0f-30e5ae401aa4)
