### PR TITLE
FEAT: MSW 설정 추가 및 대시보드 스켈레톤 UI 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,10 @@
     "extends": [
       "plugin:storybook/recommended"
     ]
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
+    "@tanstack/react-query": "^5.79.0",
+    "@tanstack/react-query-devtools": "^5.79.0",
+    "axios": "^1.9.0",
     "dayjs": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,307 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.8.5'
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Header from "@/components/Header/Header";
 
 function App() {
   const redirectionList = ["DASHBOARD", "APPLYLIST", "SETTING", "EVALUTION"];
+
   return (
     <BrowserRouter>
       <div className="h-screen bg-[#121826]">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { Routes, Route, BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Page as DashBoard } from "@/pages/DashBoard";
 import { Page as ApplyList } from "@/pages/ApplyList";
 import { Page as Setting } from "@/pages/Setting";
@@ -6,23 +8,28 @@ import { Page as Evaluation } from "@/pages/Evaluation";
 import Header from "@/components/Header/Header";
 
 function App() {
-  const redirectionList = ["DASHBOARD", "APPLYLIST", "SETTING", "EVALUTION"];
+  const queryClient = new QueryClient();
+  const redirectionList = ["DASHBOARD", "APPLY LIST", "SETTING", "EVALUTION"];
 
   return (
-    <BrowserRouter>
-      <div className="h-screen bg-[#121826]">
-        <Header redirectionList={redirectionList} />
-        <main className="h-[calc(100vh-112px)]">
-          <Routes>
-            <Route path="/" element={<></>} />
-            <Route path="/dashboard" element={<DashBoard />} />
-            <Route path="/applies" element={<ApplyList />} />
-            <Route path="/setting" element={<Setting />} />
-            <Route path="/evaluation" element={<Evaluation />} />
-          </Routes>
-        </main>
-      </div>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <div className="h-screen bg-[#121826]">
+          <Header redirectionList={redirectionList} />
+          <main className="h-[calc(100vh-112px)]">
+            <Routes>
+              <Route path="/" element={<></>} />
+              <Route path="/dashboard" element={<DashBoard />} />
+              <Route path="/applies" element={<ApplyList />} />
+              <Route path="/setting" element={<Setting />} />
+              <Route path="/evalution" element={<Evaluation />} />
+            </Routes>
+          </main>
+        </div>
+      </BrowserRouter>
+
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }
 

--- a/src/api/DashBoard/fetchChartData.ts
+++ b/src/api/DashBoard/fetchChartData.ts
@@ -1,0 +1,14 @@
+const fetchChartData = async (type: string) => {
+  try {
+    const res = await fetch(`/api/chart-data?type=${type}`);
+    if (!res.ok) {
+      throw new Error(`response status: ${res.status}`);
+    }
+    const data = await res.json();
+    return data;
+  } catch (error) {
+    console.error(`Failed to fetch chart data`, error);
+  }
+};
+
+export { fetchChartData };

--- a/src/api/DashBoard/fetchChartData.ts
+++ b/src/api/DashBoard/fetchChartData.ts
@@ -1,13 +1,15 @@
-const fetchChartData = async (type: string) => {
+import { axiosInstance } from "@/api/axiosInstance";
+import type { ChartData, ChartDataWithCount } from "@/types/chart";
+
+const fetchChartData = async (
+  type: string
+): Promise<ChartData[] | ChartDataWithCount[]> => {
   try {
-    const res = await fetch(`/api/chart-data?type=${type}`);
-    if (!res.ok) {
-      throw new Error(`response status: ${res.status}`);
-    }
-    const data = await res.json();
-    return data;
+    const res = await axiosInstance.get(`/api/chart-data?type=${type}`);
+    return res.data;
   } catch (error) {
     console.error(`Failed to fetch chart data`, error);
+    throw error;
   }
 };
 

--- a/src/api/DashBoard/handlers.ts
+++ b/src/api/DashBoard/handlers.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, delay } from "msw";
 import type { ChartData, ChartDataWithCount } from "@/types/chart";
 
 const genderData: ChartDataWithCount[] = [
@@ -15,19 +15,20 @@ const skillData: ChartData[] = [
 ];
 
 export const handlers = [
-  http.get("/api/chart-data", ({ request }) => {
+  http.get("/api/chart-data", async ({ request }) => {
     // URL에서 type 파라미터 추출
     const url = new URL(request.url);
     const type = url.searchParams.get("type");
 
-    // 10% 확률로 에러 발생
-    if (Math.random() < 0.1) {
-      return new HttpResponse(null, {
-        status: 500,
-        statusText: "Internal Server Error",
-      });
-    }
+    // // 10% 확률로 에러 발생
+    // if (Math.random() < 0.1) {
+    //   return new HttpResponse(null, {
+    //     status: 500,
+    //     statusText: "Internal Server Error",
+    //   });
+    // }
 
+    await delay(1000);
     // type에 따라 데이터 반환
     switch (type) {
       case "gender":

--- a/src/api/DashBoard/handlers.ts
+++ b/src/api/DashBoard/handlers.ts
@@ -1,0 +1,44 @@
+import { http, HttpResponse } from "msw";
+import type { ChartData, ChartDataWithCount } from "@/types/chart";
+
+const genderData: ChartDataWithCount[] = [
+  { label: "남성", ratio: 75, count: 34 },
+  { label: "여성", ratio: 25, count: 11 },
+];
+
+const skillData: ChartData[] = [
+  { label: "프론트", ratio: 35 },
+  { label: "백엔드", ratio: 25 },
+  { label: "디자인", ratio: 20 },
+  { label: "데브옵스", ratio: 13 },
+  { label: "AI", ratio: 7 },
+];
+
+export const handlers = [
+  http.get("/api/chart-data", ({ request }) => {
+    // URL에서 type 파라미터 추출
+    const url = new URL(request.url);
+    const type = url.searchParams.get("type");
+
+    // 10% 확률로 에러 발생
+    if (Math.random() < 0.1) {
+      return new HttpResponse(null, {
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+    }
+
+    // type에 따라 데이터 반환
+    switch (type) {
+      case "gender":
+        return HttpResponse.json(genderData);
+      case "skill":
+        return HttpResponse.json(skillData);
+      default:
+        return new HttpResponse(null, {
+          status: 400,
+          statusText: "Bad Request: Invalid type parameter",
+        });
+    }
+  }),
+];

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+
+/** 추후에 baseURL은 백엔드 주소로 대체예정 */
+export const axiosInstance = axios.create({
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true,
+});
+
+// axiosInstance.interceptors.request.use((config) => {
+//   const accessToken = localStorage.getItem("accessToken");
+//   if (accessToken && config.headers) {
+//     config.headers.Authorization = `Bearer ${accessToken}`;
+//   }
+//   return config;
+// });
+
+// axiosInstance.interceptors.request.use(
+//   (response) => response,
+//   async (error) => {
+//     const axiosError: AxiosError = error;
+//     const originalRequest = error.config;
+
+//     if (
+//       axiosError.response?.status === 401 &&
+//       !originalRequest.retry &&
+//       axiosError.message === "토큰 재발급이 필요합니다."
+//     ) {
+//       try {
+//         const res = await axios.post(`/v1/auth/refresh`);
+//         const newAccessToken = res.data.accessToken;
+//         localStorage.setItem("accessToken", newAccessToken);
+
+//         originalRequest.headers = {
+//           ...originalRequest.headers,
+//           Authorization: `Bearer ${newAccessToken}`,
+//         };
+
+//         return axiosInstance(originalRequest);
+//       } catch (refreshError) {
+//         console.error("토큰 갱신 실패:", refreshError);
+//         return Promise.reject(refreshError);
+//       }
+//     }
+//     return Promise.reject(error);
+//   }
+// );

--- a/src/api/msw/browser.ts
+++ b/src/api/msw/browser.ts
@@ -1,0 +1,14 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "@/api/DashBoard/handlers";
+
+export const worker = setupWorker(...handlers);
+
+// worker 시작
+export const startMSW = async () => {
+  if (process.env.NODE_ENV === "development") {
+    await worker.start({
+      onUnhandledRequest: "bypass", // MSW에서 처리되지 않는 요청은 그대로 통과
+    });
+    console.log("🔶 MSW 모킹 서버가 시작되었습니다.");
+  }
+};

--- a/src/components/Card/CountCard.tsx
+++ b/src/components/Card/CountCard.tsx
@@ -1,4 +1,4 @@
-import FlexBox from "./Layout/FlexBox";
+import FlexBox from "../Layout/FlexBox";
 
 interface CountCardProps {
   text: string;

--- a/src/components/Card/SkeletonUI/SkeletonCountCard.tsx
+++ b/src/components/Card/SkeletonUI/SkeletonCountCard.tsx
@@ -1,0 +1,17 @@
+import FlexBox from "../Layout/FlexBox";
+
+const CountCardSkeleton = () => {
+  return (
+    <FlexBox className="bg-white rounded-xl px-4 py-5 justify-between w-[420px] border border-gray-200">
+      <FlexBox className="gap-2">
+        <div className="w-[5px] h-[20px] rounded-xl bg-gray-200" />
+        <span className="text-gray-500 font-semibold">
+          <div className="w-20 h-8 bg-gray-200 rounded-lg"></div>
+        </span>
+      </FlexBox>
+      <span className="font-bold text-black text-4xl">-</span>
+    </FlexBox>
+  );
+};
+
+export default CountCardSkeleton;

--- a/src/components/Card/SkeletonUI/SkeletonCountCard.tsx
+++ b/src/components/Card/SkeletonUI/SkeletonCountCard.tsx
@@ -1,4 +1,4 @@
-import FlexBox from "../Layout/FlexBox";
+import FlexBox from "@/components/Layout/FlexBox";
 
 const CountCardSkeleton = () => {
   return (

--- a/src/components/Chart/CenterContent.tsx
+++ b/src/components/Chart/CenterContent.tsx
@@ -21,8 +21,6 @@ const CenterContent = ({ data, selectedSegment }: CenterContentProps<any>) => {
     );
   }
 
-  console.log(data);
-
   return (
     <div className="text-center">
       <div className="text-gray-500 text-sm mb-1">전체</div>

--- a/src/components/Chart/DonutChart.tsx
+++ b/src/components/Chart/DonutChart.tsx
@@ -9,7 +9,8 @@ export interface DonutChartProps<T> {
   data: T[];
   colors: string[];
 }
-const DonutChart = ({ title, data, colors }: DonutChartProps<any>) => {
+
+const DonutChart = ({ title, data = [], colors }: DonutChartProps<any>) => {
   const [selectedSegment, setSelectedSegment] = useState(null);
 
   const handleSegmentClick = (index: any) => {
@@ -75,20 +76,23 @@ const DonutChart = ({ title, data, colors }: DonutChartProps<any>) => {
   return (
     <FlexBox direction="col" className="py-4">
       <h1 className="text-lg font-bold text-gray-800">{title}</h1>
+
       <FlexBox direction="col">
         {/* 도넛 차트 */}
-        <FlexBox className="relative justify-center">
-          <svg width="400" height="400" style={{ display: "block" }}>
-            {renderChart()}
-          </svg>
-          {/* 차트 가운데 컨텐츠 */}
-          <FlexBox className="absolute inset-0 justify-center">
-            {isChartDataWithCount(data[0]) &&
-              CenterContent({ data, selectedSegment })}
-          </FlexBox>
+        <FlexBox className="relative justify-center mb-6">
+          <>
+            <svg width="400" height="400" style={{ display: "block" }}>
+              {renderChart()}
+            </svg>
+            {/* 차트 가운데 컨텐츠 */}
+            <FlexBox className="absolute inset-0 justify-center">
+              {data[0] &&
+                isChartDataWithCount(data[0]) &&
+                CenterContent({ data, selectedSegment })}
+            </FlexBox>
+          </>
         </FlexBox>
 
-        {/* 파트별 섹션 (클릭하여 비율 확인) */}
         <FlexBox className="gap-2">
           {data.map((item, index) => (
             <button

--- a/src/components/Chart/SkeletonUI/EmptyChart.tsx
+++ b/src/components/Chart/SkeletonUI/EmptyChart.tsx
@@ -1,0 +1,19 @@
+// 빈 차트 (데이터 없음)
+const EmptyChart = () => (
+  <div className="w-[400px] h-[400px] flex items-center">
+    <div className="relative w-48 h-48 mx-auto">
+      <svg width="192" height="192">
+        <circle
+          cx="96"
+          cy="96"
+          r="80"
+          fill="none"
+          stroke="#E5E7EB"
+          strokeWidth="32"
+        />
+      </svg>
+    </div>
+  </div>
+);
+
+export default EmptyChart;

--- a/src/components/Chart/SkeletonUI/SkeletonButtons.tsx
+++ b/src/components/Chart/SkeletonUI/SkeletonButtons.tsx
@@ -1,0 +1,18 @@
+import FlexBox from "../../Layout/FlexBox";
+
+// 스켈레톤 버튼들
+const SkeletonButtons = () => (
+  <FlexBox className="gap-2">
+    {[1, 2, 3, 4, 5].map((index) => (
+      <div
+        key={index}
+        className="flex items-center gap-2 p-3 rounded-lg animate-pulse"
+      >
+        <div className="w-3 h-3 rounded-full bg-gray-200"></div>
+        <div className="w-16 h-5 bg-gray-200 rounded"></div>
+      </div>
+    ))}
+  </FlexBox>
+);
+
+export default SkeletonButtons;

--- a/src/components/Chart/SkeletonUI/SkeletonButtons.tsx
+++ b/src/components/Chart/SkeletonUI/SkeletonButtons.tsx
@@ -1,4 +1,4 @@
-import FlexBox from "../../Layout/FlexBox";
+import FlexBox from "@/components/Layout/FlexBox";
 
 // 스켈레톤 버튼들
 const SkeletonButtons = () => (

--- a/src/components/Chart/SkeletonUI/SkeletonDonutChart.tsx
+++ b/src/components/Chart/SkeletonUI/SkeletonDonutChart.tsx
@@ -1,0 +1,19 @@
+import FlexBox from "@/components/Layout/FlexBox";
+import EmptyChart from "./EmptyChart";
+import SkeletonButtons from "./SkeletonButtons";
+
+const SkeletonDonutChart = () => {
+  return (
+    <FlexBox direction="col" className="py-4">
+      <div className="w-20 h-7 bg-gray-200 rounded-lg"></div>
+      <FlexBox direction="col">
+        <FlexBox className="relative justify-center mb-6">
+          <EmptyChart />
+        </FlexBox>
+        <SkeletonButtons />
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+export default SkeletonDonutChart;

--- a/src/hooks/DashBoard/useDashBoard.ts
+++ b/src/hooks/DashBoard/useDashBoard.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchChartData } from "@/api/DashBoard/fetchChartData";
+
+export const useDashBoard = () => {
+  const genderQuery = useQuery({
+    queryKey: ["chart-data", "gender"],
+    queryFn: () => fetchChartData("gender"),
+  });
+
+  const skillQuery = useQuery({
+    queryKey: ["chart-data", "skill"],
+    queryFn: () => fetchChartData("skill"),
+  });
+
+  return {
+    genderQuery,
+    skillQuery,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,21 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import { startMSW } from "./api/msw/browser";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+// MSW 시작 후 앱 렌더링
+const prepare = async () => {
+  // 개발 환경에서만 MSW 실행
+  if (import.meta.env.DEV) {
+    await startMSW();
+  }
+  
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+};
+
+prepare();

--- a/src/pages/DashBoard/index.tsx
+++ b/src/pages/DashBoard/index.tsx
@@ -1,15 +1,16 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import FlexBox from "@/components/Layout/FlexBox";
-import CountCard from "@/components/CountCard";
+import CountCard from "@/components/Card/CountCard";
 import DonutChart from "@/components/Chart/DonutChart";
 import Modal from "@/components/Modal/Modal";
 import type { ChartData, ChartDataWithCount } from "@/types/chart";
+import { fetchChartData } from "@/api/DashBoard/fetchChartData";
 
 // 차트 샘플 데이터
-const genderData: ChartDataWithCount[] = [
-  { label: "남성", ratio: 75, count: 34 },
-  { label: "여성", ratio: 25, count: 11 },
-];
+// const genderData: ChartDataWithCount[] = [
+//   { label: "남성", ratio: 75, count: 34 },
+//   { label: "여성", ratio: 25, count: 11 },
+// ];
 
 const skillData: ChartData[] = [
   { label: "프론트", ratio: 35 },
@@ -21,6 +22,16 @@ const skillData: ChartData[] = [
 
 export const Page = () => {
   const [isOpen, setIsOpen] = useState(true);
+  const [genderData, setGenderDate] = useState<ChartDataWithCount[]>([]);
+
+  useEffect(() => {
+    const fetcher = async () => {
+      const data = await fetchChartData("gender");
+      setGenderDate(data);
+    };
+    fetcher();
+  }, []);
+
   return (
     <div className="text-white">
       <FlexBox className="gap-8 px-16 pb-8 items-start" direction="col">

--- a/src/stories/components/Chart/DonutChart.stories.tsx
+++ b/src/stories/components/Chart/DonutChart.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import DonutChart from "./DonutChart";
+import DonutChart from "@/components/Chart/DonutChart";
 import type { ChartData, ChartDataWithCount } from "@/types/chart";
 
 const meta = {
@@ -41,4 +41,4 @@ export const SkillRatio: Story = {
     title: "파트별 비율",
     colors: ["#4F46E5", "#EC4899", "#F97316", "#EAB308", "#10B981"],
   },
-}; 
+};

--- a/src/stories/components/Input/Input.stories.tsx
+++ b/src/stories/components/Input/Input.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Input from "@/components/Input/Input";
+
+const meta = {
+  title: "Components/Input/Input",
+  component: Input,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "기본 입력",
+    width: "w-80",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "비활성화된 입력",
+    disabled: true,
+    width: "w-80",
+  },
+};
+
+export const Password: Story = {
+  args: {
+    type: "password",
+    placeholder: "비밀번호 입력",
+    width: "w-80",
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: "미리 입력된 값",
+    width: "w-80",
+  },
+};

--- a/src/stories/components/Input/SearchInput.stories.tsx
+++ b/src/stories/components/Input/SearchInput.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SearchInput from "@/components/Input/SearchInput";
+
+const meta = {
+  title: "Components/Input/SearchInput",
+  component: SearchInput,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof SearchInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "검색어를 입력하세요",
+    width: "w-80",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "비활성화된 검색",
+    disabled: true,
+    width: "w-80",
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: "검색어",
+    width: "w-80",
+  },
+};
+
+export const CustomWidth: Story = {
+  args: {
+    placeholder: "넓은 검색창",
+    width: "w-[400px]",
+  },
+};

--- a/src/stories/components/Input/TextArea.stories.tsx
+++ b/src/stories/components/Input/TextArea.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TextArea from "@/components/Input/TextArea";
+
+const meta = {
+  title: "Components/Input/TextArea",
+  component: TextArea,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "내용을 입력하세요",
+    width: "w-80",
+    height: "h-32",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "비활성화된 텍스트 영역",
+    disabled: true,
+    width: "w-80",
+    height: "h-32",
+  },
+};
+
+export const WithMaxLength: Story = {
+  args: {
+    placeholder: "최대 100자까지 입력 가능합니다",
+    maxLength: 100,
+    width: "w-80",
+    height: "h-32",
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: "미리 입력된 텍스트입니다.\n여러 줄 입력이 가능합니다.",
+    width: "w-80",
+    height: "h-32",
+  },
+};
+
+export const CustomSize: Story = {
+  args: {
+    placeholder: "크기 조절된 텍스트 영역",
+    width: "w-[400px]",
+    height: "h-[200px]",
+  },
+};

--- a/src/stories/pages/DashBoard/DashBoard.stories.tsx
+++ b/src/stories/pages/DashBoard/DashBoard.stories.tsx
@@ -1,36 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Page } from "@/pages/DashBoard/index";
-import { http, HttpResponse } from "msw";
+import { DashBoardMock } from "./DashBoardMock";
 
 const meta = {
   title: "Pages/DashBoard",
-  component: Page,
+  component: DashBoardMock,
   parameters: {
     layout: "fullscreen",
     backgrounds: {
       default: "dark",
-    },
-    msw: {
-      handlers: [
-        http.get("/api/dashboard", () => {
-          return HttpResponse.json({
-            totalApplicants: 200,
-            growthRate: "+10%",
-            passedApplicants: 100,
-            genderRatio: [
-              { label: "남성", ratio: 75, count: 34 },
-              { label: "여성", ratio: 25, count: 11 },
-            ],
-            skillRatio: [
-              { label: "프론트", ratio: 35 },
-              { label: "백엔드", ratio: 25 },
-              { label: "디자인", ratio: 20 },
-              { label: "데브옵스", ratio: 13 },
-              { label: "AI", ratio: 7 },
-            ],
-          });
-        }),
-      ],
     },
   },
   decorators: [
@@ -40,43 +17,11 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof Page>;
+} satisfies Meta<typeof DashBoardMock>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
-};
-
-export const Loading: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get("/api/dashboard", async () => {
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          return HttpResponse.json({
-            totalApplicants: 200,
-            growthRate: "+10%",
-            passedApplicants: 100,
-            genderRatio: [
-              { label: "남성", ratio: 75, count: 34 },
-              { label: "여성", ratio: 25, count: 11 },
-            ],
-            skillRatio: [
-              { label: "프론트", ratio: 35 },
-              { label: "백엔드", ratio: 25 },
-              { label: "디자인", ratio: 20 },
-              { label: "데브옵스", ratio: 13 },
-              { label: "AI", ratio: 7 },
-            ],
-          });
-        }),
-      ],
-    },
-  },
-};
-
-export const Error: Story = {
   args: {},
 };

--- a/src/stories/pages/DashBoard/DashBoardMock.tsx
+++ b/src/stories/pages/DashBoard/DashBoardMock.tsx
@@ -1,17 +1,56 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import FlexBox from "@/components/Layout/FlexBox";
 import CountCard from "@/components/Card/CountCard";
 import DonutChart from "@/components/Chart/DonutChart";
 import Modal from "@/components/Modal/Modal";
 import SkeletonDonutChart from "@/components/Chart/SkeletonUI/SkeletonDonutChart";
-import { useDashBoard } from "@/hooks/DashBoard/useDashBoard";
+import type { ChartData, ChartDataWithCount } from "@/types/chart";
 
-export const Page = () => {
+// 더미 데이터
+const mockGenderData: ChartDataWithCount[] = [
+  { label: "남성", ratio: 65, count: 45 },
+  { label: "여성", ratio: 35, count: 25 },
+];
+
+const mockSkillData: ChartData[] = [
+  { label: "프론트엔드", ratio: 40 },
+  { label: "백엔드", ratio: 30 },
+  { label: "디자인", ratio: 15 },
+  { label: "데브옵스", ratio: 10 },
+  { label: "AI/ML", ratio: 5 },
+];
+
+// 가짜 useDashBoard 훅
+const useDashBoardMock = () => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 컴포넌트 마운트 시 로딩 상태 시뮬레이션
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 1500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return {
+    genderQuery: {
+      data: mockGenderData,
+      isLoading,
+    },
+    skillQuery: {
+      data: mockSkillData,
+      isLoading,
+    },
+  };
+};
+
+export const DashBoardMock = () => {
   const [isOpen, setIsOpen] = useState(false);
   const {
     genderQuery: { data: genderData, isLoading: isGenderLoading },
     skillQuery: { data: skillData, isLoading: isSkillLoading },
-  } = useDashBoard();
+  } = useDashBoardMock();
 
   return (
     <div className="text-white">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,30 @@
     "@tailwindcss/oxide" "4.1.7"
     tailwindcss "4.1.7"
 
+"@tanstack/query-core@5.79.0":
+  version "5.79.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.79.0.tgz#947e13c409555a8ca0a17abdf3dff9eb77af45e6"
+  integrity sha512-s+epTqqLM0/TbJzMAK7OEhZIzh63P9sWz5HEFc5XHL4FvKQXQkcjI8F3nee+H/xVVn7mrP610nVXwOytTSYd0w==
+
+"@tanstack/query-devtools@5.76.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.76.0.tgz#ba43754ed8d23a265ed72f17de618fa9f9c7649d"
+  integrity sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==
+
+"@tanstack/react-query-devtools@^5.79.0":
+  version "5.79.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.79.0.tgz#cac922af75d2d9624c3923f548fe48b55b7f9034"
+  integrity sha512-YVRWxjxsWycWChjKxvaIAPdNC5LX0zpiHoNyTB8teDZpQstM1b7mCuAp3x60cjX1MhLoO3vbaeY29EKst4D4ug==
+  dependencies:
+    "@tanstack/query-devtools" "5.76.0"
+
+"@tanstack/react-query@^5.79.0":
+  version "5.79.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.79.0.tgz#91a41d92dcd92b2cd544bafdcc2c2bd7d06396c6"
+  integrity sha512-DjC4JIYZnYzxaTzbg3osOU63VNLP67dOrWet2cZvXgmgwAXNxfS52AMq86M5++ILuzW+BqTUEVMTjhrZ7/XBuA==
+  dependencies:
+    "@tanstack/query-core" "5.79.0"
+
 "@testing-library/dom@10.4.0", "@testing-library/dom@^10.4.0":
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
@@ -1663,12 +1687,26 @@ ast-types@^0.16.1:
   dependencies:
     tslib "^2.0.1"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1833,6 +1871,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1950,6 +1995,11 @@ define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.2, dequal@^2.0.3:
   version "2.0.3"
@@ -2071,6 +2121,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild-register@^3.5.0:
   version "3.6.0"
@@ -2331,6 +2391,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
@@ -2345,6 +2410,16 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
 
 fsevents@2.3.2:
   version "2.3.2"
@@ -3032,6 +3107,18 @@ micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 min-indent@^1.0.0, min-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -3345,6 +3432,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.15.0"
@@ -3705,6 +3797,7 @@ strict-event-emitter@^0.5.1:
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4122,6 +4215,7 @@ word-wrap@^1.2.5:
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
1. 대시보드 페이지에 대한 스켈레톤 UI 컴포넌트 개발
<img width="700" alt="스크린샷 2025-05-29 오후 7 24 49" src="https://github.com/user-attachments/assets/9f2b1439-4fc6-4ca0-bd23-db376e3c0a2d" />

```
서버에서 데이터를 받아오는 로딩중일때 보여줄 UI 컴포넌트를 추가해놓았습니다.
로딩중일때 이런걸 넣어주면 UX적으로 있어보이는 것도 있고, layout shift가 적게 발생하기 때문에 성능적으로도 좋습니다.
괜찮으시면 앞으로 서버 데이터 패칭에 의존적인 컴포넌트를 개발하실때 만들어보시면 좋을 것 같습니다.
```

2. MSW 라이브러리 설치 및 세팅
```
API 호출을 가짜(mock)로 대체하여 개발, 테스트할 수 있도록 해주는 라이브러리입니다.
백엔드 api가 다 나올려면 시간이 좀 걸리니, 그 동안 서버가 있다고 가정하고 로직이랑 다 미리 개발해놓고 나중에 연동만 진행할 수 있도록 도입해보고자 합니다. 
모킹 api는 제가 만들어놓을테니 react-query 사용하셔서 평소처럼 api 연동 진행한다고 가정하고, 추후에 페이지 개발이랑 api 연동 같이 고려하면서 진행해주시면 좋을 것 같습니다.
```

3. tanstack-query, axios 설치


