### PR TITLE
FEAT : 면접 설정 페이지 API 연동

### DIFF
--- a/src/pages/Evaluation/InterviewDetail.tsx
+++ b/src/pages/Evaluation/InterviewDetail.tsx
@@ -40,6 +40,7 @@ const InterviewDetail = () => {
     queryFn: () => fetchInterviewer("1"),
   });
   const [activeLabels, setActiveLabels] = useState(new Set());
+  const [isInitialized, setIsInitialized] = useState(false);
   const [activeTab, setActiveTab] = useState("파트별 질문");
 
   // 면접 현황 지원서 목록 데이터 패칭
@@ -49,25 +50,8 @@ const InterviewDetail = () => {
     enabled: Boolean(date) && Boolean(time)
   });
 
-  // 콘솔에 데이터 출력
-  useEffect(() => {
-    if (interviewData) {
-      console.log("=== 면접 현황 API 응답 데이터 ===");
-      console.log("API Path:", `/v1/manager/resume/interview-time?date=${date}&time=${time}`);
-      console.log("전체 응답:", interviewData);
-      console.log("result 필드:", interviewData.result);
-      console.log("resumeList:", interviewData.result?.resumeList);
-      console.log("첫 번째 지원서:", interviewData.result?.resumeList?.[0]);
-      console.log("=============================");
-    }
-  }, [interviewData, date, time]);
-  useEffect(() => {
-    console.log("질문 유형", activeTab);
-  }, [activeTab]);
-
   // 공통 질문 데이터 추출
   const commonQuestions = interviewData?.result?.resumeList?.[0]?.common?.[0]?.commonQuestions ?? [];
-  console.log("공통 질문 데이터:", commonQuestions);
   const handleActiveNames = (name: string) => {
     setActiveLabels((prev) => {
       const newSet = new Set(prev);
@@ -88,6 +72,18 @@ const InterviewDetail = () => {
 
   // 지원서 목록 추출
   const resumeList = interviewData?.result?.resumeList ?? [];
+  
+  // 지원자 이름 목록 추출
+  const applicantNames = resumeList.map((resume: any) => resume.resumeMemberInfoDto?.username).filter(Boolean);
+
+  // 1번 버튼이 처음부터 활성화되도록 초기값 설정
+  useEffect(() => {
+    if (applicantNames.length > 0 && !isInitialized) {
+      const firstHalf = applicantNames.slice(0, Math.ceil(applicantNames.length / 2));
+      setActiveLabels(new Set(firstHalf));
+      setIsInitialized(true);
+    }
+  }, [applicantNames, isInitialized]);
 
   return (
     <div className="text-white">
@@ -118,117 +114,129 @@ const InterviewDetail = () => {
         <div className="w-[1344px] mx-auto flex flex-col gap-4">
           <p className="text-gray-500 pt-8">총 면접자 {count ?? 0}명</p>
           <FlexBox className="gap-2">
-            <label
-              onClick={() => handleActiveNames("장진영")}
-              className={`w-[78px] h-[28px] text-sm flex items-center justify-center rounded-2xl font-semibold cursor-pointer ${
-                activeLabels.has("장진영")
-                  ? "bg-blue-200 text-blue-700"
-                  : "bg-gray-200 text-gray-500"
+            {applicantNames.map((name: string) => (
+              <label
+                key={name}
+               
+                className={`w-[78px] h-[28px] text-sm flex items-center justify-center rounded-2xl font-semibold  ${
+                  activeLabels.has(name)
+                    ? "bg-blue-200 text-blue-700"
+                    : "bg-gray-200 text-gray-500"
+                }`}
+              >
+                {name}
+              </label>
+            ))}
+          </FlexBox>
+          <FlexBox className="gap-2 mt-2">
+                        <button
+              onClick={() => {
+                const firstHalf = applicantNames.slice(0, Math.ceil(applicantNames.length / 2));
+                setActiveLabels(new Set(firstHalf));
+              }}
+              className={`py-2 px-4 text-sm flex items-center justify-center rounded-lg font-regular cursor-pointer ${
+                activeLabels.size > 0 && 
+                applicantNames.slice(0, Math.ceil(applicantNames.length / 2)).every((name: string) => activeLabels.has(name)) &&
+                applicantNames.slice(Math.ceil(applicantNames.length / 2)).every((name: string) => !activeLabels.has(name))
+                  ? "bg-blue-600 text-white"
+                  : "bg-blue-200 text-gray-700 hover:bg-blue-300"
               }`}
             >
-              장진영
-            </label>
-            <label
-              onClick={() => handleActiveNames("심우선")}
-              className={`w-[78px] h-[28px] text-sm flex items-center justify-center rounded-2xl font-semibold cursor-pointer ${
-                activeLabels.has("심우선")
-                  ? "bg-blue-200 text-blue-700"
-                  : "bg-gray-200 text-gray-500"
+              1~2번째 지원자 조회
+            </button>
+            <button
+              onClick={() => {
+                const secondHalf = applicantNames.slice(Math.ceil(applicantNames.length / 2));
+                setActiveLabels(new Set(secondHalf));
+              }}
+              className={`py-2 px-4 text-sm flex items-center justify-center rounded-lg font-regular cursor-pointer ${
+                activeLabels.size > 0 && 
+                applicantNames.slice(Math.ceil(applicantNames.length / 2)).every((name: string) => activeLabels.has(name)) &&
+                applicantNames.slice(0, Math.ceil(applicantNames.length / 2)).every((name: string) => !activeLabels.has(name))
+                  ? "bg-blue-600 text-white"
+                  : "bg-blue-200 text-gray-700 hover:bg-blue-300"
               }`}
             >
-              심우선
-            </label>
-            <label
-              onClick={() => handleActiveNames("양현지")}
-              className={`w-[78px] h-[28px] text-sm flex items-center justify-center rounded-2xl font-semibold cursor-pointer ${
-                activeLabels.has("양현지")
-                  ? "bg-blue-200 text-blue-700"
-                  : "bg-gray-200 text-gray-500"
-              }`}
-            >
-              양현지
-            </label>
-            <label
-              onClick={() => handleActiveNames("서현빈")}
-              className={`w-[78px] h-[28px] text-sm flex items-center justify-center rounded-2xl font-semibold cursor-pointer ${
-                activeLabels.has("서현빈")
-                  ? "bg-blue-200 text-blue-700"
-                  : "bg-gray-200 text-gray-500"
-              }`}
-            >
-              서현빈
-            </label>
+              3~4번째 지원자 조회
+            </button>
+            <div className="text-gray-500 text-sm">버튼을 누르면 지원서가 조회됩니다!</div>
           </FlexBox>
           <div className="w-full h-px border-t border-t-gray-300 mb-8" />
         </div>
-        {/* 지원서 목록을 2개씩 article로 나눠서 렌더링 */}
-        {Array.from({ length: Math.ceil(resumeList.length / 2) }).map((_, articleIdx) => (
-          <article key={articleIdx} className="w-[1344px] mx-auto flex gap-4 text-gray-900 pb-12">
-            {resumeList.slice(articleIdx * 2, articleIdx * 2 + 2).map((resume: any, idx: number) => {
-              const memberInfo = resume.resumeMemberInfoDto;
-              const partQuestions = resume.specific?.[0]?.specificQuestions ?? [];
-              const commonQuestions = resume.common?.[0]?.commonQuestions ?? [];
-              return (
-                <div key={resume.resumeId} className="flex flex-col gap-4 rounded-lg border border-gray-300 bg-white w-1/2 px-6 py-4">
-                  <FlexBox className="gap-2">
-                    <h2 className="font-bold text-xl">{memberInfo?.username ?? '-'}</h2>
-                    <Chip title={memberInfo?.field as any ?? '-'} />
-                  </FlexBox>
-                  <div className="grid grid-cols-2 gap-4">
-                    <FlexBox className="gap-4">
-                      <label htmlFor="gender" className="text-gray-500">성별</label>
-                      <p id="gender">{memberInfo?.sex ?? '-'}</p>
+        {/* 선택된 지원자들의 지원서만 렌더링 */}
+        {(() => {
+          const selectedResumes = resumeList.filter((resume: any) => 
+            activeLabels.has(resume.resumeMemberInfoDto?.username)
+          );
+          
+          return Array.from({ length: Math.ceil(selectedResumes.length / 2) }).map((_, articleIdx) => (
+            <article key={articleIdx} className="w-[1344px] mx-auto flex gap-4 text-gray-900 pb-12">
+              {selectedResumes.slice(articleIdx * 2, articleIdx * 2 + 2).map((resume: any, idx: number) => {
+                const memberInfo = resume.resumeMemberInfoDto;
+                const partQuestions = resume.specific?.[0]?.specificQuestions ?? [];
+                const commonQuestions = resume.common?.[0]?.commonQuestions ?? [];
+                return (
+                  <div key={resume.resumeId} className="flex flex-col gap-4 rounded-lg border border-gray-300 bg-white w-1/2 px-6 py-4">
+                    <FlexBox className="gap-2">
+                      <h2 className="font-bold text-xl">{memberInfo?.username ?? '-'}</h2>
+                      <Chip title={memberInfo?.field as any ?? '-'} />
                     </FlexBox>
-                    <FlexBox className="gap-4">
-                      <label htmlFor="school" className="text-gray-500">학교</label>
-                      <p id="school">{memberInfo?.univ ?? '-'}</p>
-                    </FlexBox>
-                    <FlexBox className="gap-4">
-                      <label htmlFor="birth" className="text-gray-500">생년월일</label>
-                      <p id="birth">{memberInfo?.birthday ?? '-'}</p>
-                    </FlexBox>
-                    <FlexBox className="gap-4">
-                      <label htmlFor="major" className="text-gray-500">전공</label>
-                      <p id="major">{memberInfo?.major ?? '-'}</p>
+                    <div className="grid grid-cols-2 gap-4">
+                      <FlexBox className="gap-4">
+                        <label htmlFor="gender" className="text-gray-500">성별</label>
+                        <p id="gender">{memberInfo?.sex ?? '-'}</p>
+                      </FlexBox>
+                      <FlexBox className="gap-4">
+                        <label htmlFor="school" className="text-gray-500">학교</label>
+                        <p id="school">{memberInfo?.univ ?? '-'}</p>
+                      </FlexBox>
+                      <FlexBox className="gap-4">
+                        <label htmlFor="birth" className="text-gray-500">생년월일</label>
+                        <p id="birth">{memberInfo?.birthday ?? '-'}</p>
+                      </FlexBox>
+                      <FlexBox className="gap-4">
+                        <label htmlFor="major" className="text-gray-500">전공</label>
+                        <p id="major">{memberInfo?.major ?? '-'}</p>
+                      </FlexBox>
+                    </div>
+                    <Tab
+                      categories={["파트별 질문", "공통 질문"]}
+                      active={activeTab}
+                      onChange={setActiveTab}
+                      className="pt-8"
+                    />
+                    <FlexBox direction="col" className="gap-8 overflow-y-scroll py-6">
+                      {activeTab === "공통 질문" &&
+                        commonQuestions.map((q: any) => (
+                          <Accordion key={q.id} title={q.question} className="w-full">
+                            <TextArea
+                              value={q.answer ?? "미답변"}
+                              readOnly={true}
+                              className="w-full h-full"
+                            />
+                          </Accordion>
+                        ))}
+                      {activeTab === "파트별 질문" &&
+                        partQuestions.map((q: any, index: number) => (
+                          <Accordion
+                            key={q.id}
+                            title={q.question}
+                            className="w-full"
+                          >
+                            <TextArea
+                              value={q.answer ?? "미답변"}
+                              readOnly={true}
+                              className="w-full h-full"
+                            />
+                          </Accordion>
+                        ))}
                     </FlexBox>
                   </div>
-                  <Tab
-                    categories={["파트별 질문", "공통 질문"]}
-                    active={activeTab}
-                    onChange={setActiveTab}
-                    className="pt-8"
-                  />
-                  <FlexBox direction="col" className="gap-8 overflow-y-scroll py-6">
-                    {activeTab === "공통 질문" &&
-                      commonQuestions.map((q: any) => (
-                        <Accordion key={q.id} title={q.question} className="w-full">
-                          <TextArea
-                            value={q.answer ?? "미답변"}
-                            readOnly={true}
-                            className="w-full h-full"
-                          />
-                        </Accordion>
-                      ))}
-                    {activeTab === "파트별 질문" &&
-                      partQuestions.map((q: any, index: number) => (
-                        <Accordion
-                          key={q.id}
-                          title={q.question}
-                          className="w-full"
-                        >
-                          <TextArea
-                            value={q.answer ?? "미답변"}
-                            readOnly={true}
-                            className="w-full h-full"
-                          />
-                        </Accordion>
-                      ))}
-                  </FlexBox>
-                </div>
-              );
-            })}
-          </article>
-        ))}
+                );
+              })}
+            </article>
+          ));
+        })()}
       </Body>
     </div>
   );

--- a/src/pages/Setting/Interview/Detail.tsx
+++ b/src/pages/Setting/Interview/Detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import FlexBox from "@/components/Layout/FlexBox";
@@ -7,6 +7,7 @@ import Tab from "@/components/Tab/Tab";
 import Accordion from "@/components/Accordion/Accordion";
 import { fetchMemberInfo, fetchResumeQuestions } from "@/pages/Evaluation/api";
 import { postInterviewDate } from "@/pages/Setting/api/Interview";
+import { axiosInstance } from "@/api/axiosInstance";
 import type { Resume } from "@/types/interview";
 import TextArea from "@/components/Input/TextArea";
 import TimePicker from "@/components/DatePicker/TimePicker";
@@ -14,6 +15,16 @@ import Button from "@/components/Button/Button";
 import ToastMessage from "@/components/Modal/ToastMessage";
 import Icon from "@/components/Icon/Icon";
 import { formatMMDD, formatHHMin } from "@/utils/formatDate";
+
+// 이 페이지에서만 사용할 날짜 포맷 함수 (요일 포함, 괄호 없음)
+const formatDateWithDay = (isoString: string) => {
+  const date = new Date(isoString);
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const dayNames = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+  const day = dayNames[date.getDay()];
+  return `${mm}.${dd} ${day}`;
+};
 import { useMutation } from "@tanstack/react-query";
 
 const tabCategories = ["파트별 질문", "공통 질문"];
@@ -27,9 +38,9 @@ const InterviewSettingDetail = () => {
 
   // 지원자 정보 조회
   const { data: memberInfo, isLoading: memberInfoLoading } = useQuery({
-    queryKey: ["member-info", id],
-    queryFn: () => fetchMemberInfo(id || ""),
-    enabled: !!id,
+    queryKey: ["member-info", application?.memberId],
+    queryFn: () => fetchMemberInfo(application?.memberId?.toString() || ""),
+    enabled: !!application?.memberId,
   });
 
   // 지원서 질문 정보 조회
@@ -40,20 +51,46 @@ const InterviewSettingDetail = () => {
   });
 
   const [activeTab, setActiveTab] = useState("공통 질문");
-  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedDateTime, setSelectedDateTime] = useState("");
   const [isToastOpen, setIsToastOpen] = useState(false);
 
-  // 면접 일자 선택을 위한 샘플 데이터
-  const schedules = [
-    "2025-11-20T13:00:00.96078",
-    "2025-11-20T13:30:00.96078",
-    "2025-11-20T14:00:00.96078",
-    "2025-11-20T14:30:00.96078",
-    "2025-11-20T15:00:00.96078",
-    "2025-11-20T15:30:00.96078",
-    "2025-11-20T16:00:00.96078",
-    "2025-11-20T16:30:00.96078",
-  ];
+  // 전체 면접 날짜+시간 조회
+  const { data: interviewTimeConfig, isLoading: interviewTimeLoading } = useQuery({
+    queryKey: ["interview-time-config"],
+    queryFn: async () => {
+      const res = await axiosInstance.get("/v1/member/config/interview-time");
+      return res.data;
+    },
+  });
+
+  // 면접 일자 선택을 위한 데이터 - API에서 가져온 데이터 사용
+  const schedules = useMemo(() => {
+    if (!interviewTimeConfig?.result) return [];
+    
+    return interviewTimeConfig.result.map((item: any) => item.time);
+  }, [interviewTimeConfig]);
+
+  // 날짜별로 그룹화된 시간 데이터
+  const groupedSchedules = useMemo(() => {
+    if (!schedules.length) return [];
+    
+    const grouped: Record<string, string[]> = {};
+    
+    schedules.forEach((timeStr: string) => {
+      const date = new Date(timeStr);
+      const dateKey = date.toISOString().split('T')[0]; // YYYY-MM-DD 형식
+      
+      if (!grouped[dateKey]) {
+        grouped[dateKey] = [];
+      }
+      grouped[dateKey].push(timeStr);
+    });
+    
+    return Object.entries(grouped).map(([date, times]) => ({
+      date,
+      times: times.sort() // 시간순 정렬
+    }));
+  }, [schedules]);
 
   // 면접 일자 업데이트 mutation
   const {
@@ -73,7 +110,7 @@ const InterviewSettingDetail = () => {
   });
 
   const handleUpdateInterviewData = () => {
-    mutate({ selectedDate });
+    mutate({ selectedDate: selectedDateTime });
   };
 
   // 지원자 기본 정보는 API에서 가져온 데이터 우선 사용, 없으면 state에서 가져오기
@@ -103,21 +140,7 @@ const InterviewSettingDetail = () => {
     }
   };
 
-  const isLoading = memberInfoLoading || questionsLoading;
-
-  // 응답 데이터 로깅
-  console.log("=== 면접 설정 상세 페이지 데이터 ===");
-  console.log("URL 파라미터 id:", id);
-  console.log("State application:", application);
-  console.log("지원자 정보 API 응답:", memberInfo);
-  console.log("질문 정보 API 응답:", resumeQuestions);
-  console.log("가공된 지원자 정보:", applicant);
-  console.log("가공된 질문 정보:", questions);
-  console.log("공통 질문:", commonQuestions);
-  console.log("파트별 질문:", partQuestions);
-  console.log("로딩 상태:", { memberInfoLoading, questionsLoading, isLoading });
-  console.log("=============================");
-
+  const isLoading = memberInfoLoading || questionsLoading || interviewTimeLoading;
   return (
     <div className="text-white">
       <FlexBox className="gap-8 px-16 pb-8 items-start" direction="col">
@@ -213,17 +236,17 @@ const InterviewSettingDetail = () => {
             <FlexBox direction="col" className="gap-4">
               <div className="w-full border-t border-gray-300 mt-6"></div>
               <TimePicker>
-                {Array.from({ length: 4 }, (_, index) => (
+                {groupedSchedules.map((group, index) => (
                   <TimePicker.DateRow
-                    key={index}
-                    date={formatMMDD(schedules[0])}
+                    key={group.date}
+                    date={formatDateWithDay(group.date)}
                   >
-                    {schedules.map((timeSlot: string, timeIndex: number) => (
+                    {group.times.map((timeSlot: string, timeIndex: number) => (
                       <TimePicker.TimeSlotButton
                         key={timeSlot + timeIndex}
                         time={formatHHMin(timeSlot)}
-                        isSelected={selectedDate === formatHHMin(timeSlot)}
-                        onClick={() => setSelectedDate(formatHHMin(timeSlot))}
+                        isSelected={selectedDateTime === timeSlot}
+                        onClick={() => setSelectedDateTime(timeSlot)}
                       />
                     ))}
                   </TimePicker.DateRow>

--- a/src/pages/Setting/Interview/TimeTable.tsx
+++ b/src/pages/Setting/Interview/TimeTable.tsx
@@ -75,8 +75,9 @@ const TimeTable = () => {
         setCurrentPage={setCurrentPage}
         rows={tableRows}
         isLoading={isLoading}
-        baseUrl="/setting/interview"
-        navigate={navigate}
+        // 아래 두 줄 주석처리 해제 시 상세 조회로 이동
+        // baseUrl="/setting/interview"
+        // navigate={navigate}
         pageType="interview"
       />
     </div>

--- a/src/pages/Setting/Interview/TimeTable.tsx
+++ b/src/pages/Setting/Interview/TimeTable.tsx
@@ -38,9 +38,6 @@ const TimeTable = () => {
     handleFilter,
   } = useFilter<InterviewItem>(entireList);
 
-  console.log("전체 리스트:", entireList);
-
-
   return (
     <div className="flex flex-col gap-4">
       <FlexBox className="justify-between">

--- a/src/pages/Setting/api/FinalPass.ts
+++ b/src/pages/Setting/api/FinalPass.ts
@@ -8,24 +8,10 @@ const formatDateTimeForBackend = (dateTimeStr: string): string => {
 
 const fetchSettingFinalPass = async () => {
   try {
-    console.log("=== 최종 합격 안내 조회 API 호출 ===");
-    console.log("API 경로:", "/v1/member/final-pass");
-    console.log("현재 토큰:", sessionStorage.getItem("access_token"));
-    
     const res = await axiosInstance.get("/v1/member/final-pass");
-    console.log("API 응답:", res.data);
-    console.log("응답 상태:", res.status);
-    console.log("=============================");
     return res.data;
   } catch (error: any) {
-    console.error("=== 최종 합격 안내 조회 API 에러 ===");
-    console.error("에러 타입:", typeof error);
-    console.error("에러 메시지:", error?.message);
-    console.error("에러 응답:", error?.response);
-    console.error("에러 상태:", error?.response?.status);
-    console.error("에러 데이터:", error?.response?.data);
-    console.error("전체 에러:", error);
-    console.error("=============================");
+
     return error;
   }
 };

--- a/src/pages/Setting/api/FinalPass.ts
+++ b/src/pages/Setting/api/FinalPass.ts
@@ -1,18 +1,46 @@
 import { axiosInstance } from "@/api/axiosInstance";
 import type { FinalPassResult } from "./types";
 
+const formatDateTimeForBackend = (dateTimeStr: string): string => {
+  if (!dateTimeStr) return "";
+  return dateTimeStr.replace(/\.\d{3}Z$/, "");
+};
+
 const fetchSettingFinalPass = async () => {
   try {
+    console.log("=== 최종 합격 안내 조회 API 호출 ===");
+    console.log("API 경로:", "/v1/member/final-pass");
+    console.log("현재 토큰:", sessionStorage.getItem("access_token"));
+    
     const res = await axiosInstance.get("/v1/member/final-pass");
+    console.log("API 응답:", res.data);
+    console.log("응답 상태:", res.status);
+    console.log("=============================");
     return res.data;
-  } catch (error) {
+  } catch (error: any) {
+    console.error("=== 최종 합격 안내 조회 API 에러 ===");
+    console.error("에러 타입:", typeof error);
+    console.error("에러 메시지:", error?.message);
+    console.error("에러 응답:", error?.response);
+    console.error("에러 상태:", error?.response?.status);
+    console.error("에러 데이터:", error?.response?.data);
+    console.error("전체 에러:", error);
+    console.error("=============================");
     return error;
   }
 };
 
 const postSettingFinalPass = async (data : FinalPassResult) => {
   try {
-    const res = await axiosInstance.post("/v1/admin/final-pass", data);
+    // 백엔드 형식에 맞게 날짜 변환
+    const formattedData = {
+      ...data,
+      feeDeadline: formatDateTimeForBackend(data.feeDeadline),
+      surveyDeadline: formatDateTimeForBackend(data.surveyDeadline),
+      otDeadline: formatDateTimeForBackend(data.otDeadline),
+    };
+
+    const res = await axiosInstance.post("/v1/admin/final-pass", formattedData);
     return res.data;
   } catch (error: any) {
     throw error; 


### PR DESCRIPTION
1. 면접 설정 페이지에서 지원자 리스트 조회하는 API 연동
-> Table 클릭 시, 피그마 디자인 상으로는 수동으로 면접 일자+시간을 선택해서 저장하는 페이지로 이동하지만 
실제로 API가 없고 사용하지 않아 Table 클릭을 막아두었습니다.

<img width="839" height="563" alt="스크린샷 2025-07-30 오전 4 08 24" src="https://github.com/user-attachments/assets/27535485-bf15-44c1-b2f6-b416af81a7c9" />

2. 최종 합격 안내 설정 API가 백엔드에서 변경되어 수정했습니다.
3. 면접 현황 API에 지원서 상세 조회와 분할 조회 버튼을 추가했습니다.
- 면접 현황 테이블
<img width="836" height="513" alt="스크린샷 2025-07-30 오전 4 08 31" src="https://github.com/user-attachments/assets/7605767b-9528-4289-b6ba-605bc69725b8" />

- 지원자 클릭 -> 지원서 상세 조회
<img width="843" height="555" alt="스크린샷 2025-07-30 오전 4 08 37" src="https://github.com/user-attachments/assets/93e7997d-f487-4033-834a-0b7b11e4044b" />

: '1-2번째 지원자 조회' 버튼 또는 '3-4번째 지원자 조회' 버튼을 누르면 지원자가 2명씩 선택되어 지원서가 아래에 출력됩니다.
(스크린샷은 동일 날짜, 동일 시간대에 지원자가 1명이라 1명만 뜸)