### PR TITLE
FIX : 테이블 행 개수 수정 및 페이지 계산 수정

### DIFF
--- a/src/components/ApplicationTable/ApplicationTable.tsx
+++ b/src/components/ApplicationTable/ApplicationTable.tsx
@@ -88,7 +88,7 @@ const ApplicationTable = ({
 
   return (
     <div className="w-full overflow-x-auto">
-      <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden h-[574px]">
+      <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden h-[656px]">
         <table className="border-separate border-spacing-0 table-auto w-full">
           <thead className="bg-white">
             <tr className="rounded-t-xl overflow-hidden">

--- a/src/components/TimeTable.tsx
+++ b/src/components/TimeTable.tsx
@@ -47,16 +47,16 @@ const TimeTable = ({ timeTable, onCellClick }: TimeTableProps) => {
   const timeSlots = getAllTimeSlots();
 
   return (
-    <table className="w-full h-full rounded-xl bg-[#F3F4F6]">
+    <table className="w-full h-full rounded-xl bg-[#F3F4F6] table-fixed">
       <thead>
         <tr className="border-b border-gray-300">
-          <th className="p-4 text-left font-medium border-r border-r-gray-300 text-gray-700">
+          <th className="p-4 text-left font-medium border-r border-r-gray-300 text-gray-700 w-24">
             시간
           </th>
           {timeTable.map((day) => (
             <th
               key={day.groupByDay}
-              className="w-8 text-center font-semibold text-gray-700 border-r border-gray-300 last:border-r-0"
+              className="text-center font-semibold text-gray-700 border-r border-gray-300 last:border-r-0"
             >
               {formatKorDate(day.groupByDay)} ({day.dayName[0]})
             </th>
@@ -80,7 +80,7 @@ const TimeTable = ({ timeTable, onCellClick }: TimeTableProps) => {
             className="border-b border-gray-300 last:border-b-0 text-gray-900 font-semibold"
           >
               <td
-                className={`p-4 text-center border-r border-gray-300 align-top hover:bg-blue-100 hover:text-blue-600 cursor-pointer
+                className={`p-4 text-center border-r border-gray-300 align-top hover:bg-blue-100 hover:text-blue-600 cursor-pointer w-24
                   ${isCurrent ? 'bg-blue-100 border-l-4 border-l-blue-600 text-blue-600' : ''}`}
               >
               {timeSlot}
@@ -98,16 +98,16 @@ const TimeTable = ({ timeTable, onCellClick }: TimeTableProps) => {
                       if (onCellClick) onCellClick(day.groupByDay, timeSlot);
                       navigate(`/evaluation/interview/${day.groupByDay}`);
                     }}
-                    className={`border-r border-gray-300 w-1/${timeTable.length} bg-gray-50 hover:bg-gray-100 cursor-pointer ${isPast ? 'bg-gray-100' : ''}`}
+                    className={`border-r border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer ${isPast ? 'bg-gray-100' : ''}`}
                 >
-                  <div className="p-2 h-full min-h-[120px]">
-                    <div className="grid grid-cols-2 gap-2 p-2">
+                  <div className="p-2 h-full min-h-[160px] max-h-[200px] overflow-y-auto">
+                    <div className="grid grid-cols-2 gap-1">
                       {members.map((member) => (
                         <div
                           key={member.memberId}
-                            className="flex flex-col items-start gap-2 border border-gray-300 rounded-xl p-3 hover:border-t-4 hover:border-blue-500 hover:border-t-blue-500 hover:bg-white hover:shadow-md"
+                            className="flex flex-col items-start gap-1 border border-gray-300 rounded-lg p-2 hover:border-t-2 hover:border-blue-500 hover:border-t-blue-500 hover:bg-white hover:shadow-sm text-sm"
                         >
-                          <span className="font-semibold">
+                          <span className="font-semibold text-xs truncate w-full">
                             {member.username}
                           </span>
                           <Chip title={member.field} />

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -48,6 +48,7 @@ export const usePagination = <T>({
 
     // 현재 페이지의 쿼리만 처리
     const currentPageQuery = pageQueries[page];
+    
     if (currentPageQuery?.isSuccess && currentPageQuery.data?.result) {
       if (currentPageQuery.data.result.dataList) {
         const transformedData = currentPageQuery.data.result.dataList.map((item: any) => ({
@@ -101,24 +102,38 @@ export const usePagination = <T>({
     };
   }, [pageQueries[0]?.dataUpdatedAt]); // 첫 번째 쿼리의 dataUpdatedAt만 사용
 
-  // totalPages를 별도로 계산하여 모든 페이지에서 올바른 값 반환
+  // totalPages를 totalRecruiter와 size를 기반으로 계산
   const totalPages = useMemo(() => {
-    // 첫 번째 페이지 쿼리에서 totalPages 정보 가져오기
+    // 첫 번째 페이지 쿼리에서 totalRecruiter 정보 가져오기
     const firstQuery = pageQueries[0];
+    
     if (firstQuery?.isSuccess && firstQuery.data?.result) {
-      // resumeResDtos.page.totalPages 구조 확인
+      const totalRecruiter = firstQuery.data.result.totalRecruiter;
+      
+      if (totalRecruiter !== undefined && totalRecruiter !== null) {
+        // totalRecruiter를 size로 나누어 올림하여 totalPages 계산
+        const calculatedTotalPages = Math.ceil(totalRecruiter / size);
+        console.log("=== totalPages 계산 ===");
+        console.log("totalRecruiter:", totalRecruiter);
+        console.log("size:", size);
+        console.log("계산된 totalPages:", calculatedTotalPages);
+        return calculatedTotalPages;
+      }
+    }
+    
+    // fallback: 기존 구조들 확인
+    if (firstQuery?.isSuccess && firstQuery.data?.result) {
       if (firstQuery.data.result.resumeResDtos?.page?.totalPages) {
         return firstQuery.data.result.resumeResDtos.page.totalPages;
-      }
-      // 기존 구조들도 유지
-      else if (firstQuery.data.result.totalPage) {
+      } else if (firstQuery.data.result.totalPage) {
         return firstQuery.data.result.totalPage;
       } else if (firstQuery.data.result.dtos?.page?.totalPages) {
         return firstQuery.data.result.dtos.page.totalPages;
       }
     }
+    
     return totalPagesRef.current || 1;
-  }, [pageQueries[0]?.dataUpdatedAt]); // 첫 번째 쿼리의 dataUpdatedAt만 사용
+  }, [pageQueries[0]?.dataUpdatedAt, size]); // size도 의존성에 추가
 
   const isLoading = pageQueries.some((query) => query.isLoading);
   return {

--- a/src/pages/Evaluation/Document.tsx
+++ b/src/pages/Evaluation/Document.tsx
@@ -35,7 +35,7 @@ const Document = () => {
   const { entireList, isLoading, totalPages, countData } = usePagination<EvaluationItem>({
     type: "서류 평가",
     page: currentPage - 1,
-    size: 6,
+    size: 7,
     status: currentStatus,
   });
   

--- a/src/pages/Evaluation/Final.tsx
+++ b/src/pages/Evaluation/Final.tsx
@@ -61,7 +61,7 @@ const Final = () => {
     usePagination<FinalEvaluationItem>({
       type: "최종 서류 평가",
       page: currentPage - 1,
-      size: 6,
+      size: 7,
       status: getStatusFromTab(currentTab),
     });
 

--- a/src/pages/Evaluation/FinalInterview.tsx
+++ b/src/pages/Evaluation/FinalInterview.tsx
@@ -44,7 +44,7 @@ const FinalInterview = () => {
   const { entireList, isLoading, totalPages,countData } = usePagination<EvaluationItem>({
     type: "최종 면접 평가",
     page: currentPage - 1, // 0-based index로 변환
-    size: 6,
+    size: 7,
     status: getStatusFromTab(activeTab),
   });
 

--- a/src/pages/Evaluation/Interview.tsx
+++ b/src/pages/Evaluation/Interview.tsx
@@ -62,7 +62,7 @@ const Interview = () => {
         </FlexBox>
       </FlexBox>
       <Body className="pt-8 gap-8">
-        <FlexBox className="justify-between w-[1320px] rounded-xl border border-gray-300 mx-auto">
+        <FlexBox className="justify-between w-full max-w-[1400px] rounded-xl border border-gray-300 mx-auto overflow-hidden">
           <TimeTable timeTable={timeTable} onCellClick={handleCellClick} />
         </FlexBox>
         <FlexBox className="mx-auto gap-4 justify-center pb-12">

--- a/src/pages/Setting/Interview/TimeTable.tsx
+++ b/src/pages/Setting/Interview/TimeTable.tsx
@@ -27,7 +27,7 @@ const TimeTable = () => {
   const { entireList, isLoading, totalPages } = usePagination<InterviewItem>({
     type: "면접 설정",
     page: currentPage - 1,
-    size: 6,
+    size: 7,
   });
 
   const {


### PR DESCRIPTION
## 작성 내용
1. 테이블(`ApplicationTable`)의 행을 6->7로 조정
+ 행 개수에 맞게 높이 값 수정
2. 페이지 계산 수정 (`pagination`) : 첫 번째 페이지 쿼리에서 전체 지원자 수 (`totalRecruiter`) 정보를 가져와서 페이지 수를 계산하도록 수정

## 스트린샷
<img width="1012" height="723" alt="image" src="https://github.com/user-attachments/assets/6e3a467a-1eb8-4629-acd4-7994dceeac03" />
