### PR TITLE
FEAT : 면접 시간 설정 버튼 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ function App() {
                 path="/evaluation/interview/final/:id"
                 element={<FinalEvaluationDetail type="interview"/>}
               />
+
             </Routes>
           </main>
         </div>

--- a/src/components/Draggable/Item.tsx
+++ b/src/components/Draggable/Item.tsx
@@ -8,7 +8,6 @@ import Switch from "../Input/Switch";
 import ChipController from "@/pages/Setting/Document/ChipController";
 import WordLimitModal from "@/pages/Setting/Document/WordLimitModal";
 import TypeChangeModal from "@/pages/Setting/Document/TypeChangeModal";
-import InterviewScheduleModal from "@/pages/Setting/Document/InterviewScheduleModal";
 import ToastMessage from "@/components/Modal/ToastMessage";
 import { axiosInstance } from "@/api/axiosInstance";
 
@@ -387,7 +386,7 @@ const DraggableItem = ({
             console.log("데이터 무효화 완료");
           }}
         />
-        <InterviewScheduleModal ref={interviewScheduleModal} />
+    
       </div>
       {(displayChips.length > 0 || questionData?.answerType === "PROGRAMMING") && (
         <div className="px-4 pb-4">

--- a/src/components/Draggable/Item.tsx
+++ b/src/components/Draggable/Item.tsx
@@ -344,14 +344,14 @@ const DraggableItem = ({
             )}
           </div>
 
-          {item.textLength && (
+          {/* {item.textLength && (
             <button
               className="p-2 border border-gray-300 rounded-lg hover:bg-blue-100 cursor-pointer"
               onClick={() => wordLimitModalRef.current?.showModal()}
             >
               <Icon type="TextLength" size={20} />
             </button>
-          )}
+          )} */}
 
           <button
             className="p-2 border border-gray-300 rounded-lg hover:bg-blue-100 cursor-pointer"

--- a/src/pages/Setting/Interview/InterviewScheduleModal.tsx
+++ b/src/pages/Setting/Interview/InterviewScheduleModal.tsx
@@ -9,11 +9,21 @@ import ToastMessage from "@/components/Modal/ToastMessage";
 
 const options = ["15분", "20분", "25분", "30분"];
 
+interface InterviewScheduleModalProps {
+  dialogRef: React.RefObject<HTMLDialogElement | null>;
+  onConfirm: () => void;
+  isPending?: boolean;
+  confirmText?: string;
+  title?: string;
+}
+
 const InterviewScheduleModal = ({
-  ref,
-}: {
-  ref: React.RefObject<HTMLDialogElement | null>;
-}) => {
+  dialogRef,
+  onConfirm,
+  isPending = false,
+  confirmText = "저장",
+  title = "면접 시간 설정"
+}: InterviewScheduleModalProps) => {
   const [selected, setSelected] = useState("15분");
   const [open, setOpen] = useState(false);
 
@@ -51,8 +61,8 @@ const InterviewScheduleModal = ({
         
         // 성공 후 모달 닫기
         setTimeout(() => {
-          if (ref && 'current' in ref && ref.current) {
-            ref.current.close();
+          if (dialogRef && 'current' in dialogRef && dialogRef.current) {
+            dialogRef.current.close();
           }
         }, 2000);
       } else {
@@ -69,10 +79,10 @@ const InterviewScheduleModal = ({
 
   return (
     <Modal
-      dialogRef={ref}
-      title="면접 시간 설정"
+      dialogRef={dialogRef}
+      title={title}
       buttonCount={2}
-      confirmText="등록"
+      confirmText={confirmText}
       isPending={isLoading}
       onConfirm={updateInterviewSchedule}
       width=""
@@ -170,8 +180,8 @@ const InterviewScheduleModal = ({
         isOpen={isToastOpen}
         setIsOpen={(open) => {
           setIsToastOpen(open);
-          if (!open && ref && 'current' in ref && ref.current) {
-            ref.current.close();
+          if (!open && dialogRef && 'current' in dialogRef && dialogRef.current) {
+            dialogRef.current.close();
           }
         }}
       />

--- a/src/pages/Setting/Interview/index.tsx
+++ b/src/pages/Setting/Interview/index.tsx
@@ -20,6 +20,7 @@ import { useMutation } from "@tanstack/react-query";
 import ToastMessage from "@/components/Modal/ToastMessage";
 import Default from "./Default";
 import TimeTable from "./TimeTable";
+import InterviewScheduleModal from "./InterviewScheduleModal";
 
 const tabCategories = ["면접 시간표 등록", "기본 설정"];
 
@@ -33,6 +34,7 @@ const InterviewSetting = () => {
   const CurrentTab = interviewSettingPageMap[activeTab];
 
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const interviewScheduleDialogRef = useRef<HTMLDialogElement>(null);
   const [isToastOpen, setIsToastOpen] = useState(false);
   const [isDownloadingTimeTable, setIsDownloadingTimeTable] = useState(false);
   const [isDownloadingInterviewer, setIsDownloadingInterviewer] = useState(false);
@@ -113,6 +115,20 @@ const InterviewSetting = () => {
   const openModal = () => {
     if (dialogRef) {
       dialogRef.current?.showModal();
+    }
+  };
+
+  const openInterviewScheduleModal = () => {
+    if (interviewScheduleDialogRef) {
+      interviewScheduleDialogRef.current?.showModal();
+    }
+  };
+
+  const handleInterviewScheduleSave = () => {
+    setToastMessage("면접 시간이 성공적으로 저장되었습니다.");
+    setIsToastOpen(true);
+    if (interviewScheduleDialogRef.current) {
+      interviewScheduleDialogRef.current.close();
     }
   };
 
@@ -234,10 +250,16 @@ const InterviewSetting = () => {
     <div className="text-white">
       <FlexBox className="gap-8 px-16 pb-8 items-start" direction="col">
         <h1 className="font-bold text-4xl">면접 설정</h1>
-        <Button onClick={openModal}>
-          <Icon type="Plus" size={18} />
-          시간표 등록하기
-        </Button>
+        <FlexBox className="gap-4">
+          <Button onClick={openModal}>
+            <Icon type="Plus" size={18} />
+            시간표 등록하기
+          </Button>
+          <Button onClick={openInterviewScheduleModal}>
+            <Icon type="Arrow" size={18} />
+            면접 시간 설정
+          </Button>
+        </FlexBox>
       </FlexBox>
       <Body className="py-8 gap-8 px-12">
         <Tab
@@ -485,9 +507,17 @@ const InterviewSetting = () => {
             </div>
           </div>
         </div>
-      </Modal>
-    </div>
-  );
+                      </Modal>
+
+        <InterviewScheduleModal
+          dialogRef={interviewScheduleDialogRef}
+          onConfirm={handleInterviewScheduleSave}
+          isPending={false}
+          confirmText="저장"
+          title="면접 시간 설정"
+        />
+      </div>
+    );
 };
 
 export default InterviewSetting;


### PR DESCRIPTION
## 작업 내용
기존에 서류설정>질문(`Type=TIME`)>면접일정수정 단계를 거쳐야 나왔던 면접 시간 모달을
면접 설정 페이지로 옮기고 버튼을 만들었습니다.
면접 시간 설정을 서류 질문에 제한되어 설정할 수 있었기에 지원 페이지에 불필요한 질문이 생겼는데, 이를 삭제하여 질문 리스트를 정리하고
면접 설정 페이지로 옮겨 조금 더 직관적으로 확인할 수 있습니다.

## 스크린샷
<img width="838" height="522" alt="image" src="https://github.com/user-attachments/assets/e164ea70-7b39-4ef1-913b-afcf4fcd16ea" />
