### PR TITLE
FEAT : 대시보드 API 추가 및 연결

### DIFF
--- a/src/components/Chart/DonutChart.tsx
+++ b/src/components/Chart/DonutChart.tsx
@@ -22,6 +22,60 @@ const DonutChart = ({ title, data = [], colors }: DonutChartProps<any>) => {
 
     return data.map((item, index) => {
       const angle = (item.ratio / 100) * 360;
+      console.log(`Item ${index}: ${item.label}, ratio: ${item.ratio}, angle: ${angle}, color: ${colors[index]}`);
+      
+      // 100% 비율인 경우 전체 원을 그리기 위한 특별 처리
+      if (item.ratio === 100) {
+        console.log("100% 항목 색상:", colors[index]);
+        
+        // 간단한 원형 도넛 차트 직접 생성
+        const centerX = 200;
+        const centerY = 200;
+        const outerRadius = selectedSegment === index ? 108 : 100;
+        const innerRadius = 60;
+        
+        return (
+          <g key={index} className="block">
+            {/* 외부 원 */}
+            <circle
+              cx={centerX}
+              cy={centerY}
+              r={outerRadius}
+              fill={colors[index]}
+              style={{
+                cursor: "pointer",
+                transition: "all 0.3s ease",
+                filter: selectedSegment === index ? "brightness(1.1)" : "none",
+              }}
+              onClick={() => handleSegmentClick(index)}
+            />
+            {/* 내부 원 (구멍) */}
+            <circle
+              cx={centerX}
+              cy={centerY}
+              r={innerRadius}
+              fill="white"
+              style={{ pointerEvents: "none" }}
+            />
+            {/* 텍스트 - count가 0인 경우 숨김 */}
+            {item.count > 0 && (
+              <text
+                x={centerX}
+                y={centerY - 20}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#111827"
+                fontSize="12"
+                fontWeight="600"
+                style={{ pointerEvents: "none", transition: "all 0.3s ease" }}
+              >
+                {item.label} ({Math.round(item.ratio)}%)
+              </text>
+            )}
+          </g>
+        );
+      }
+      
       const path = createPath(
         currentAngle,
         currentAngle + angle,
@@ -33,7 +87,6 @@ const DonutChart = ({ title, data = [], colors }: DonutChartProps<any>) => {
       const textPos = getTextPosition(midAngle, selectedSegment === index);
 
       currentAngle += angle;
-
       return (
         <g key={index} className="block">
           <path
@@ -46,28 +99,33 @@ const DonutChart = ({ title, data = [], colors }: DonutChartProps<any>) => {
             }}
             onClick={() => handleSegmentClick(index)}
           />
-          {/* 연결선 */}
-          <line
-            x1={textPos.lineStart.x}
-            y1={textPos.lineStart.y}
-            x2={textPos.lineEnd.x}
-            y2={textPos.lineEnd.y}
-            stroke="#6B7280"
-            strokeWidth="1"
-            style={{ transition: "all 0.3s ease" }}
-          />
-          <text
-            x={textPos.text.x}
-            y={textPos.text.y}
-            textAnchor={textPos.text.x > 200 ? "start" : "end"}
-            dominantBaseline="middle"
-            fill="#111827"
-            fontSize="12"
-            fontWeight="600"
-            style={{ pointerEvents: "none", transition: "all 0.3s ease" }}
-          >
-            {item.topic} ({Math.round(item.ratio)}%)
-          </text>
+          {/* 연결선 - count가 0인 경우 숨김 */}
+          {item.count > 0 && (
+            <line
+              x1={textPos.lineStart.x}
+              y1={textPos.lineStart.y}
+              x2={textPos.lineEnd.x}
+              y2={textPos.lineEnd.y}
+              stroke="#6B7280"
+              strokeWidth="1"
+              style={{ transition: "all 0.3s ease" }}
+            />
+          )}
+          {/* 텍스트 - count가 0인 경우 숨김 */}
+          {item.count > 0 && (
+            <text
+              x={textPos.text.x}
+              y={textPos.text.y}
+              textAnchor={textPos.text.x > 200 ? "start" : "end"}
+              dominantBaseline="middle"
+              fill="#111827"
+              fontSize="12"
+              fontWeight="600"
+              style={{ pointerEvents: "none", transition: "all 0.3s ease" }}
+            >
+              {item.label} ({Math.round(item.ratio)}%)
+            </text>
+          )}
         </g>
       );
     });
@@ -109,7 +167,7 @@ const DonutChart = ({ title, data = [], colors }: DonutChartProps<any>) => {
                 style={{ backgroundColor: colors[index] }}
               ></div>
               <span className="text-gray-700 text-sm font-medium whitespace-nowrap">
-                {item.topic}
+                {item.label}
               </span>
             </button>
           ))}

--- a/src/components/Chart/DonutChart.tsx
+++ b/src/components/Chart/DonutChart.tsx
@@ -26,8 +26,6 @@ const DonutChart = ({ title, data = [], colors }: DonutChartProps<any>) => {
       
       // 100% 비율인 경우 전체 원을 그리기 위한 특별 처리
       if (item.ratio === 100) {
-        console.log("100% 항목 색상:", colors[index]);
-        
         // 간단한 원형 도넛 차트 직접 생성
         const centerX = 200;
         const centerY = 200;

--- a/src/hooks/DashBoard/useDashBoard.ts
+++ b/src/hooks/DashBoard/useDashBoard.ts
@@ -20,8 +20,8 @@ interface DashboardResponse {
 export const useDashBoard = () => {
   const fetchChartData = async (): Promise<DashboardResponse> => {
     try {
-      const res = await axiosInstance.get(`/v1/admin/dashboard`);
-      // console.log("res", res);
+      const res = await axiosInstance.get(`/v1/manager/dashboard`);
+      console.log("res", res);
       return res.data;
     } catch (error) {
       console.error(`Failed to fetch chart data`, error);
@@ -32,13 +32,21 @@ export const useDashBoard = () => {
   const genderQuery = useQuery({
     queryKey: ["chart-data", "gender"],
     queryFn: fetchChartData,
-    select: (data: DashboardResponse) => data.result.sexRatioDtos,
+    select: (data: DashboardResponse) => data.result.sexRatioDtos.map(item => ({
+      label: item.topic,
+      count: item.count,
+      ratio: item.ratio
+    })),
   });
 
   const skillQuery = useQuery({
     queryKey: ["chart-data", "skill"],
     queryFn: fetchChartData,
-    select: (data: DashboardResponse) => data.result.fieldRatioDtos,
+    select: (data: DashboardResponse) => data.result.fieldRatioDtos.map(item => ({
+      label: item.topic,
+      count: item.count,
+      ratio: item.ratio
+    })),
   });
 
   const dashboardQuery = useQuery({

--- a/src/pages/DashBoard/index.tsx
+++ b/src/pages/DashBoard/index.tsx
@@ -7,12 +7,21 @@ import Modal from "@/components/Modal/Modal";
 import { formatDateTime } from "@/utils/formatDate";
 import SkeletonDonutChart from "@/components/Chart/SkeletonUI/SkeletonDonutChart";
 import { useDashBoard } from "@/hooks/DashBoard/useDashBoard";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchSettingDefault } from "@/pages/Setting/api/Default";
+import { axiosInstance } from "@/api/axiosInstance";
+
+// 대시보드 업데이트 API 함수
+const updateDashboard = async () => {
+  const response = await axiosInstance.post("/v1/manager/dashboard");
+  return response.data;
+};
 
 export const Page = () => {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  
   const {
     genderQuery: {
       data: genderData,
@@ -35,6 +44,27 @@ export const Page = () => {
     queryKey: ["setting", "default"],
     queryFn: fetchSettingDefault,
     staleTime: 1000 * 60 * 60 * 24,
+  });
+
+  // 대시보드 업데이트 mutation
+  const updateDashboardMutation = useMutation({
+    mutationFn: updateDashboard,
+    onSuccess: async () => {
+      console.log("대시보드 업데이트 완료");
+      
+      // POST 요청 성공 후 GET 요청으로 최신 데이터 조회
+      try {
+        await queryClient.refetchQueries({ queryKey: ["chart-data", "dashboard"] });
+        await queryClient.refetchQueries({ queryKey: ["chart-data", "gender"] });
+        await queryClient.refetchQueries({ queryKey: ["chart-data", "skill"] });
+        console.log("대시보드 데이터 재조회 완료");
+      } catch (error) {
+        console.error("대시보드 데이터 재조회 실패:", error);
+      }
+    },
+    onError: (error) => {
+      console.error("대시보드 업데이트 실패:", error);
+    }
   });
 
   const calculateSum = () => {
@@ -60,6 +90,11 @@ export const Page = () => {
     const documentStartDate = new Date(defaultSettingData.result.documentRecruitStartDate);
     
     return currentDate < documentStartDate;
+  };
+
+  // 대시보드 업데이트 핸들러
+  const handleDashboardUpdate = () => {
+    updateDashboardMutation.mutate();
   };
 
   return (
@@ -133,6 +168,12 @@ export const Page = () => {
             )}
           </div>
         </FlexBox>
+        <button 
+        className="mx-auto w-44 py-1 bg-blue-600 text-white px-4 py-2 rounded-md cursor-pointer hover:bg-blue-700 disabled:bg-gray-400"
+        onClick={handleDashboardUpdate}
+        disabled={updateDashboardMutation.isPending}>
+          {updateDashboardMutation.isPending ? "업데이트 중..." : "대시보드 업데이트"}
+        </button>
                 {(() => {
           // 기본 설정에 generation이 없으면 모달 표시
           if (defaultSettingData?.result?.generation) {


### PR DESCRIPTION
## 작업내용

대시보드 데이터가 바로 적용되지 않는 문제를 처리했습니다
대시보드 페이지 하단에 '대시보드 업데이트' 버튼을 생성하고, POST로 백엔드에게 업데이트 요청을 보냅니다.
업데이트 요청 직후 GET으로 다시 조회하면 대시보드가 업데이트 됩니다.

## 스크린샷
<img width="841" height="568" alt="스크린샷 2025-08-03 오후 8 08 45" src="https://github.com/user-attachments/assets/ce3a96d8-cbbe-4c74-8764-bf861c5c0a4b" />
(예시 데이터를 넣었습니다)