### PR TITLE
FEAT : 이름, 분야 전체 데이터 검색

### DIFF
--- a/src/api/fetchList.ts
+++ b/src/api/fetchList.ts
@@ -73,18 +73,7 @@ export const fetchList = async (
       }
     }
 
-    console.log("=== fetchList API 요청 ===");
-    console.log("전달받은 type (ApplicationType):", type);
-    console.log("전달받은 params:", params);
-    console.log("추출된 pageType:", extractedPageType);
-    console.log("추출된 type (지원분야):", extractedType);
-    console.log("최종 URL:", url);
-    console.log("최종 requestParams:", requestParams);
-
-
     const res = await axiosInstance.get(url, { params: requestParams });
-
-    console.log("응답 데이터:", res.data);
     return res.data;
   } catch (error: any) {
     console.error("전체 에러:", error);

--- a/src/api/fetchList.ts
+++ b/src/api/fetchList.ts
@@ -5,6 +5,9 @@ export interface Pagination {
   page: number;
   size: number;
   status?: Status;
+  name?: string;
+  pageType?: string;
+  type?: string;
 }
 
 export interface InterviewTimeParams {
@@ -19,18 +22,31 @@ export const fetchList = async (
   try {
     let url = "";
     let requestParams: Record<string, any> = {};
+    let extractedPageType: string | undefined;
+    let extractedType: string | undefined;
 
     if (type === "면접 현황") {
       const { date, time } = params as InterviewTimeParams;
       url = "/v1/manager/resume/interview-time";
       requestParams = { date, time };
     } else {
-      const { page, size, status } = params as Pagination;
+      const { page, size, status, name, pageType, type: fieldType } = params as Pagination;
+      extractedPageType = pageType;
+      extractedType = fieldType;
       requestParams = { page, size };
       if (status !== undefined && status !== null) {
         requestParams.status = status;
       }
-      switch (type) {
+      if (name && name.trim() !== "") {
+        requestParams.name = name.trim();
+      }
+      if (pageType && pageType.trim() !== "") {
+        requestParams.pageType = pageType;
+      }
+      if (fieldType && fieldType.trim() !== "") {
+        requestParams.type = fieldType;
+      }
+      switch (pageType) {
         case "알림 신청":
           url = "/v1/admin/notification";
           break;
@@ -58,9 +74,13 @@ export const fetchList = async (
     }
 
     console.log("=== fetchList API 요청 ===");
-    console.log("Params:", requestParams);
-    console.log("URL:", url);
-    console.log("Type:", type);
+    console.log("전달받은 type (ApplicationType):", type);
+    console.log("전달받은 params:", params);
+    console.log("추출된 pageType:", extractedPageType);
+    console.log("추출된 type (지원분야):", extractedType);
+    console.log("최종 URL:", url);
+    console.log("최종 requestParams:", requestParams);
+
 
     const res = await axiosInstance.get(url, { params: requestParams });
 

--- a/src/components/Button/FilterButton.tsx
+++ b/src/components/Button/FilterButton.tsx
@@ -1,39 +1,73 @@
-import type { RoleType } from "@/types/role";
+import type { RoleType } from "@/types/role.d";
 import Icon from "@/components/Icon/Icon";
-import CheckBox from "@/components/Input/CheckBox";
 
 const filters: RoleType[] = [
-  "디자인",
-  "웹 프론트",
-  "앱 프론트",
-  "백엔드",
-  "데이터 분석",
-  "딥러닝",
+  "DESIGN",
+  "WEBFRONTEND",
+  "APPFRONTEND",
+  "BACKEND",
+  "DATAANALYSIS",
+  "DEEPLEARNING",
 ];
 
+const roleDisplayNames: Record<RoleType, string> = {
+  DESIGN: "디자인",
+  WEBFRONTEND: "웹 프론트",
+  APPFRONTEND: "앱 프론트",
+  BACKEND: "백엔드",
+  DATAANALYSIS: "데이터 분석",
+  DEEPLEARNING: "딥러닝",
+};
+
 interface FilterButtonProps {
-  checkedList: Set<RoleType>;
-  onChange: (role: RoleType) => void;
+  selectedRole: RoleType | null;
+  onChange: (role: RoleType | null) => void;
 }
 
-const FilterButton = ({ checkedList, onChange }: FilterButtonProps) => {
+const FilterButton = ({ selectedRole, onChange }: FilterButtonProps) => {
+  const handleRoleClick = (role: RoleType) => {
+    if (selectedRole === role) {
+      onChange(null); // 이미 선택된 경우 선택 해제
+    } else {
+      onChange(role); // 새로운 역할 선택
+    }
+  };
+
   return (
     <details className="relative">
       <summary className="flex items-center gap-2 px-4 py-3 rounded-lg bg-white text-gray-700 focus:outline outline-gray-300 font-medium cursor-pointer">
         <Icon type="Filter" size={18} />
         지원분야
       </summary>
-      <div
-        className={`absolute top-full left-0 mt-2 px-4 py-3 bg-white border border-gray-300 rounded-lg min-w-48 z-10`}
-      >
+      <div className="absolute top-full left-0 mt-2 px-4 py-3 bg-white border border-gray-300 rounded-lg min-w-48 z-10">
         {filters.map((role) => (
-          <CheckBox
+          <div
             key={role}
-            text={role}
-            isChecked={checkedList.has(role)}
-            onChange={() => onChange(role)}
-          />
+            className="flex items-center gap-3 py-2 cursor-pointer hover:bg-gray-50"
+            onClick={() => handleRoleClick(role)}
+          >
+            <div
+              className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${
+                selectedRole === role
+                  ? "border-blue-500 bg-blue-500"
+                  : "border-gray-300"
+              }`}
+            >
+              {selectedRole === role && (
+                <div className="w-2 h-2 rounded-full bg-white"></div>
+              )}
+            </div>
+            <span className="text-gray-700">{roleDisplayNames[role]}</span>
+          </div>
         ))}
+        {selectedRole && (
+          <div
+            className="flex items-center gap-3 py-2 cursor-pointer hover:bg-gray-50 text-red-500"
+            onClick={() => onChange(null)}
+          >
+            <span className="text-sm">선택 해제</span>
+          </div>
+        )}
       </div>
     </details>
   );

--- a/src/components/Input/SearchInput.tsx
+++ b/src/components/Input/SearchInput.tsx
@@ -5,6 +5,7 @@ import Input from "./Input";
 interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -14,6 +15,7 @@ interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
 const SearchInput = ({
   value,
   onChange,
+  onKeyDown,
   placeholder,
   className = "",
   disabled = false,
@@ -24,6 +26,7 @@ const SearchInput = ({
       <Input
         value={value}
         onChange={onChange}
+        onKeyDown={onKeyDown}
         placeholder={placeholder}
         disabled={disabled}
         width={width}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import Icon from "@/components/Icon/Icon";
+import { useState, useMemo, useEffect } from "react";
 
 interface PaginationProps {
   currentPage: number;
@@ -11,45 +12,83 @@ const Pagination: React.FC<PaginationProps> = ({
   totalPages,
   onPageChange,
 }) => {
+  const [pageGroup, setPageGroup] = useState(0);
+  
+  // 현재 페이지 그룹 계산
+  const currentPageGroup = useMemo(() => {
+    return Math.floor((currentPage - 1) / 10);
+  }, [currentPage]);
+  
+  // 페이지 그룹이 변경되면 상태 업데이트
+  useEffect(() => {
+    if (currentPageGroup !== pageGroup) {
+      setPageGroup(currentPageGroup);
+    }
+  }, [currentPageGroup, pageGroup]);
+  
+  // 표시할 페이지 번호들 계산
+  const visiblePages = useMemo(() => {
+    const startPage = pageGroup * 10 + 1;
+    const endPage = Math.min(startPage + 9, totalPages);
+    return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
+  }, [pageGroup, totalPages]);
+  
+  // 이전 페이지 그룹으로 이동
+  const goToPreviousGroup = () => {
+    if (pageGroup > 0) {
+      setPageGroup(pageGroup - 1);
+      onPageChange(pageGroup * 10);
+    }
+  };
+  
+  // 다음 페이지 그룹으로 이동
+  const goToNextGroup = () => {
+    if ((pageGroup + 1) * 10 < totalPages) {
+      setPageGroup(pageGroup + 1);
+      onPageChange((pageGroup + 1) * 10 + 1);
+    }
+  };
+
   return (
     <div className="flex justify-center items-center space-x-2 mt-4">
-      {/* 이전 페이지 */}
-      <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
-        className={`p-2 rounded-md flex items-center cursor-pointer ${
-          currentPage === 1 ? "opacity-50 cursor-not-allowed" : ""
-        }`}
-        aria-label="이전 페이지"
-      >
-        <Icon type="ChevronUp" size={20} className="rotate-270" />
-      </button>
+      {/* 이전 페이지 그룹 (10페이지 이상일 때만 표시) */}
+      {totalPages > 10 && pageGroup > 0 && (
+        <button
+          onClick={goToPreviousGroup}
+          className="p-2 rounded-md flex items-center cursor-pointer"
+          aria-label="이전 페이지 그룹"
+        >
+          <Icon type="ChevronUp" size={16} className="rotate-270" />
+          <Icon type="ChevronUp" size={16} className="rotate-270 ml-[-8px]" />
+        </button>
+      )}
 
       {/* 페이지 번호 */}
-      {Array.from({ length: totalPages }, (_, i) => (
+      {visiblePages.map((page) => (
         <button
-          key={i + 1}
-          onClick={() => onPageChange(i + 1)}
+          key={page}
+          onClick={() => onPageChange(page)}
           className={`w-9 h-9 justify-start rounded-lg text-sm font-bold cursor-pointer ${
-            currentPage === i + 1
+            currentPage === page
               ? "bg-blue-600 text-white"
               : "text-gray-600 text-sm font-bold"
           }`}
         >
-          {i + 1}
+          {page}
         </button>
       ))}
-      {/* 다음 페이지 */}
-      <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-        className={`p-2 rounded-md flex items-center cursor-pointer ${
-          currentPage === totalPages ? "opacity-50 cursor-not-allowed" : ""
-        }`}
-        aria-label="다음 페이지"
-      >
-        <Icon type="ChevronUp" size={20} className="rotate-90" />
-      </button>
+
+      {/* 다음 페이지 그룹 (10페이지 이상일 때만 표시) */}
+      {totalPages > 10 && (pageGroup + 1) * 10 < totalPages && (
+        <button
+          onClick={goToNextGroup}
+          className="p-2 rounded-md flex items-center cursor-pointer"
+          aria-label="다음 페이지 그룹"
+        >
+          <Icon type="ChevronUp" size={16} className="rotate-90" />
+          <Icon type="ChevronUp" size={16} className="rotate-90 ml-[-8px]" />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -119,10 +119,6 @@ export const usePagination = <T>({
       if (totalRecruiter !== undefined && totalRecruiter !== null) {
         // totalRecruiter를 size로 나누어 올림하여 totalPages 계산
         const calculatedTotalPages = Math.ceil(totalRecruiter / size);
-        console.log("=== totalPages 계산 ===");
-        console.log("totalRecruiter:", totalRecruiter);
-        console.log("size:", size);
-        console.log("계산된 totalPages:", calculatedTotalPages);
         return calculatedTotalPages;
       }
     }

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -3,13 +3,18 @@ import { fetchList, type Pagination } from "@/api/fetchList";
 import { type ApplicationType } from "@/types/application";
 import { useQueries } from "@tanstack/react-query";
 
-type UseFilterProps = { type: ApplicationType } & Pagination;
+type UseFilterProps = { 
+  pageType: ApplicationType;
+  type?: string; // 지원 분야 필터
+} & Pagination;
 
 export const usePagination = <T>({
+  pageType,
   type,
   page,
   size,
   status,
+  name,
 }: UseFilterProps) => {
   const totalPagesRef = useRef<number>(undefined);
   const maxPageRef = useRef<number>(0);
@@ -30,13 +35,14 @@ export const usePagination = <T>({
       const pageNum = index ;
       const queryParams =
         status === "ALL"
-          ? { page: pageNum, size}
-          : { page: pageNum, size, status: status };
+          ? { page: pageNum, size, ...(name && { name }), ...(type && { type }) }
+          : { page: pageNum, size, status: status, ...(name && { name }), ...(type && { type }) };
+
 
 
       return {
-        queryKey: [type, "list", pageNum, status, size, page],
-        queryFn: () => fetchList(type as ApplicationType, queryParams),
+        queryKey: [pageType, "list", pageNum, status, size, page, name, type],
+        queryFn: () => fetchList(pageType as ApplicationType, { ...queryParams, pageType }),
         staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
       };
     }),
@@ -83,7 +89,7 @@ export const usePagination = <T>({
     }
     return allData;
 
-  }, [pageQueries, page, status]); // pageQueries, page, status 변경 시 재계산
+  }, [pageQueries, page, status, name, type]); // pageQueries, page, status, name, type 변경 시 재계산
 
   // API 응답에서 count 데이터 추출
   const countData = useMemo(() => {

--- a/src/pages/Evaluation/Document.tsx
+++ b/src/pages/Evaluation/Document.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Body from "@/components/Layout/Body";
 import FlexBox from "@/components/Layout/FlexBox";
@@ -10,7 +10,8 @@ import FilterButton from "@/components/Button/FilterButton";
 import ApplicationTable from "@/components/ApplicationTable/ApplicationTable";
 import { type EvaluationItem } from "@/types/application";
 import { usePagination } from "@/hooks/usePagination";
-import { useFilter } from "@/hooks/useFilter";
+import { type RoleType } from "@/types/role.d";
+
 
 const Document = () => {
   const navigate = useNavigate();
@@ -32,29 +33,44 @@ const Document = () => {
   const [activeTab, setActiveTab] = useState("전체");
   const currentStatus = getStatusFromTab(activeTab);
 
+  const [searchInput, setSearchInput] = useState("");
+  const [searchValue, setSearchValue] = useState("");
+  const [selectedRole, setSelectedRole] = useState<RoleType | null>(null);
+
   const { entireList, isLoading, totalPages, countData } = usePagination<EvaluationItem>({
-    type: "서류 평가",
+    pageType: "서류 평가",
     page: currentPage - 1,
     size: 7,
     status: currentStatus,
+    name: searchInput,
+    type: selectedRole || undefined,
   });
-  
-
-  const {
-    filteredList,
-    checkedRoles,
-    searchInput,
-    activeTab: filterActiveTab,
-    setActiveTab: setFilterActiveTab,
-    setSearchInput,
-    handleFilter,
-  } = useFilter<EvaluationItem>(entireList);
 
   const handleTabChange = (tab: string) => { 
     setActiveTab(tab);
-    setFilterActiveTab(tab);
     setCurrentPage(1);
   };
+
+  const handleFilter = (role: RoleType | null) => {
+    setSelectedRole(role);
+  };
+
+  // 검색어 변경 시 로그 출력
+  useEffect(() => {
+    console.log("=== Document.tsx 검색어 변경 ===");
+    console.log("searchInput:", searchInput);
+    console.log("searchValue:", searchValue);
+    console.log("전달되는 name 파라미터:", searchInput);
+    console.log("name 파라미터 길이:", searchInput.length);
+  }, [searchInput, searchValue]);
+
+  // usePagination 호출 시 파라미터 확인
+  useEffect(() => {
+    console.log("=== Document.tsx usePagination 파라미터 ===");
+    console.log("전달되는 name:", searchInput);
+    console.log("전달되는 type:", selectedRole);
+    console.log("전달되는 pageType:", "서류 평가");
+  }, [searchInput, selectedRole]);
 
 
   return (
@@ -87,11 +103,17 @@ const Document = () => {
           />
 
           <FlexBox className="gap-4">
-            <FilterButton checkedList={checkedRoles} onChange={handleFilter} />
+            <FilterButton selectedRole={selectedRole} onChange={handleFilter} />
             <SearchInput
               placeholder="이름을 입력해주세요"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  console.log("Enter 키 입력됨, searchValue:", searchValue);
+                  setSearchInput(searchValue);
+                }
+              }}
             />
           </FlexBox>
         </FlexBox>
@@ -105,7 +127,7 @@ const Document = () => {
               "지원 날짜",
               "평가 여부",
             ]}
-            applications={filteredList}
+            applications={entireList}
             totalPages={totalPages}
             isLoading={isLoading}
             currentPage={currentPage}

--- a/src/pages/Evaluation/Document.tsx
+++ b/src/pages/Evaluation/Document.tsx
@@ -55,22 +55,7 @@ const Document = () => {
     setSelectedRole(role);
   };
 
-  // 검색어 변경 시 로그 출력
-  useEffect(() => {
-    console.log("=== Document.tsx 검색어 변경 ===");
-    console.log("searchInput:", searchInput);
-    console.log("searchValue:", searchValue);
-    console.log("전달되는 name 파라미터:", searchInput);
-    console.log("name 파라미터 길이:", searchInput.length);
-  }, [searchInput, searchValue]);
 
-  // usePagination 호출 시 파라미터 확인
-  useEffect(() => {
-    console.log("=== Document.tsx usePagination 파라미터 ===");
-    console.log("전달되는 name:", searchInput);
-    console.log("전달되는 type:", selectedRole);
-    console.log("전달되는 pageType:", "서류 평가");
-  }, [searchInput, selectedRole]);
 
 
   return (
@@ -112,6 +97,7 @@ const Document = () => {
                 if (e.key === 'Enter') {
                   console.log("Enter 키 입력됨, searchValue:", searchValue);
                   setSearchInput(searchValue);
+                  setCurrentPage(1); // 검색 시 1페이지로 이동
                 }
               }}
             />

--- a/src/pages/Evaluation/Final.tsx
+++ b/src/pages/Evaluation/Final.tsx
@@ -74,22 +74,7 @@ const Final = () => {
     setSelectedRole(role);
   };
 
-  // 검색어 변경 시 로그 출력
-  useEffect(() => {
-    console.log("=== Final.tsx 검색어 변경 ===");
-    console.log("searchInput:", searchInput);
-    console.log("searchValue:", searchValue);
-    console.log("전달되는 name 파라미터:", searchInput);
-    console.log("name 파라미터 길이:", searchInput.length);
-  }, [searchInput, searchValue]);
 
-  // usePagination 호출 시 파라미터 확인
-  useEffect(() => {
-    console.log("=== Final.tsx usePagination 파라미터 ===");
-    console.log("전달되는 name:", searchInput);
-    console.log("전달되는 type:", selectedRole);
-    console.log("전달되는 pageType:", "최종 서류 평가");
-  }, [searchInput, selectedRole]);
 
   const openModal = () => {
   //서류 평가 상태 : FAIL, PASS, HOLD, NOTCHECKED, COMPLETE
@@ -244,6 +229,7 @@ useEffect(() => {
                 if (e.key === 'Enter') {
                   console.log("Enter 키 입력됨, searchValue:", searchValue);
                   setSearchInput(searchValue);
+                  setCurrentPage(1); // 검색 시 1페이지로 이동
                 }
               }}
             />

--- a/src/pages/Evaluation/Final.tsx
+++ b/src/pages/Evaluation/Final.tsx
@@ -13,7 +13,7 @@ import FilterButton from "@/components/Button/FilterButton";
 import ApplicationTable from "@/components/ApplicationTable/ApplicationTable";
 import { type FinalEvaluationItem } from "@/types/application";
 import { usePagination } from "@/hooks/usePagination";
-import { useFilter } from "@/hooks/useFilter";
+import { type RoleType } from "@/types/role.d";
 import Button from "@/components/Button/Button";
 import { getRecruitmentEmailCancel, getRecruitmentEmailConfig, getRecruitmentDocumentEmailFind } from "./api";
 
@@ -26,6 +26,9 @@ const Final = () => {
 
 
   const [emailConfig , setEmailConfig] = useState(false); 
+  const [selectedRole, setSelectedRole] = useState<RoleType | null>(null);
+  const [searchInput, setSearchInput] = useState("");
+  const [searchValue, setSearchValue] = useState("");
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -59,21 +62,34 @@ const Final = () => {
   const { entireList, isLoading, totalPages, countData } =
 
     usePagination<FinalEvaluationItem>({
-      type: "최종 서류 평가",
+      pageType: "최종 서류 평가",
       page: currentPage - 1,
       size: 7,
       status: getStatusFromTab(currentTab),
+      name: searchInput,
+      type: selectedRole || undefined,
     });
 
-  const {
-    filteredList,
-    checkedRoles,
-    searchInput,
-    activeTab,
-    setActiveTab,
-    setSearchInput,
-    handleFilter,
-  } = useFilter<FinalEvaluationItem>(entireList);
+  const handleFilter = (role: RoleType | null) => {
+    setSelectedRole(role);
+  };
+
+  // 검색어 변경 시 로그 출력
+  useEffect(() => {
+    console.log("=== Final.tsx 검색어 변경 ===");
+    console.log("searchInput:", searchInput);
+    console.log("searchValue:", searchValue);
+    console.log("전달되는 name 파라미터:", searchInput);
+    console.log("name 파라미터 길이:", searchInput.length);
+  }, [searchInput, searchValue]);
+
+  // usePagination 호출 시 파라미터 확인
+  useEffect(() => {
+    console.log("=== Final.tsx usePagination 파라미터 ===");
+    console.log("전달되는 name:", searchInput);
+    console.log("전달되는 type:", selectedRole);
+    console.log("전달되는 pageType:", "최종 서류 평가");
+  }, [searchInput, selectedRole]);
 
   const openModal = () => {
   //서류 평가 상태 : FAIL, PASS, HOLD, NOTCHECKED, COMPLETE
@@ -211,7 +227,6 @@ useEffect(() => {
             categories={["전체", "평가 진행 전", "불합격", "합격"]}
             active={currentTab}
             onChange={(tab) => {
-              setActiveTab(tab);
               setCurrentTab(tab);
               setCurrentPage(1);
               // 탭 변경 시 캐시 무효화
@@ -220,11 +235,17 @@ useEffect(() => {
           />
 
           <FlexBox className="gap-4">
-            <FilterButton checkedList={checkedRoles} onChange={handleFilter} />
+            <FilterButton selectedRole={selectedRole} onChange={handleFilter} />
             <SearchInput
               placeholder="이름을 입력해주세요"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  console.log("Enter 키 입력됨, searchValue:", searchValue);
+                  setSearchInput(searchValue);
+                }
+              }}
             />
           </FlexBox>
         </FlexBox>
@@ -238,7 +259,7 @@ useEffect(() => {
               "평가 완료 인원",
               "최종 평가",
             ]}
-            applications={filteredList}
+            applications={entireList}
             totalPages={totalPages}
             isLoading={isLoading}
             currentPage={currentPage}

--- a/src/pages/Evaluation/FinalInterview.tsx
+++ b/src/pages/Evaluation/FinalInterview.tsx
@@ -65,22 +65,7 @@ const FinalInterview = () => {
     setSelectedRole(role);
   };
 
-  // 검색어 변경 시 로그 출력
-  useEffect(() => {
-    console.log("=== FinalInterview.tsx 검색어 변경 ===");
-    console.log("searchInput:", searchInput);
-    console.log("searchValue:", searchValue);
-    console.log("전달되는 name 파라미터:", searchInput);
-    console.log("name 파라미터 길이:", searchInput.length);
-  }, [searchInput, searchValue]);
 
-  // usePagination 호출 시 파라미터 확인
-  useEffect(() => {
-    console.log("=== FinalInterview.tsx usePagination 파라미터 ===");
-    console.log("전달되는 name:", searchInput);
-    console.log("전달되는 type:", selectedRole);
-    console.log("전달되는 pageType:", "최종 면접 평가");
-  }, [searchInput, selectedRole]);
 
   // 응답 데이터 로깅
   useEffect(() => {
@@ -260,6 +245,7 @@ const FinalInterview = () => {
                 if (e.key === 'Enter') {
                   console.log("Enter 키 입력됨, searchValue:", searchValue);
                   setSearchInput(searchValue);
+                  setCurrentPage(1); // 검색 시 1페이지로 이동
                 }
               }}
             />

--- a/src/pages/Evaluation/FinalInterview.tsx
+++ b/src/pages/Evaluation/FinalInterview.tsx
@@ -11,7 +11,7 @@ import FilterButton from "@/components/Button/FilterButton";
 import ApplicationTable from "@/components/ApplicationTable/ApplicationTable";
 import { type EvaluationItem } from "@/types/application";
 import { usePagination } from "@/hooks/usePagination";
-import { useFilter } from "@/hooks/useFilter";
+import { type RoleType } from "@/types/role.d";
 import Button from "@/components/Button/Button";
 import { getFinalInterviewEmailCancel, getFinalInterviewEmailConfig, getFinalInterviewEmailFind } from "./api";
 import Modal from "@/components/Modal/Modal";
@@ -25,6 +25,9 @@ const FinalInterview = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [emailConfig , setEmailConfig] = useState(false);
   const [activeTab, setActiveTab] = useState("전체");
+  const [selectedRole, setSelectedRole] = useState<RoleType | null>(null);
+  const [searchInput, setSearchInput] = useState("");
+  const [searchValue, setSearchValue] = useState("");
 
   const getStatusFromTab = (tab: string) => {
     switch (tab) {
@@ -42,27 +45,42 @@ const FinalInterview = () => {
   };
 
   const { entireList, isLoading, totalPages,countData } = usePagination<EvaluationItem>({
-    type: "최종 면접 평가",
+    pageType: "최종 면접 평가",
     page: currentPage - 1, // 0-based index로 변환
     size: 7,
     status: getStatusFromTab(activeTab),
+    name: searchInput,
+    type: selectedRole || undefined,
   });
 
   // API 요청 데이터 로깅
   console.log("=== 최종 면접 평가 API 요청 정보 ===");
-  console.log("type:", "최종 면접 평가");
+  console.log("pageType:", "최종 면접 평가");
   console.log("page:", currentPage);
-  console.log("size:", 6);
+  console.log("size:", 7);
   console.log("status:", getStatusFromTab(activeTab));
   console.log("=============================");
 
-  const {
-    filteredList,
-    checkedRoles,
-    searchInput,
-    setSearchInput,
-    handleFilter,
-  } = useFilter<EvaluationItem>(entireList);
+  const handleFilter = (role: RoleType | null) => {
+    setSelectedRole(role);
+  };
+
+  // 검색어 변경 시 로그 출력
+  useEffect(() => {
+    console.log("=== FinalInterview.tsx 검색어 변경 ===");
+    console.log("searchInput:", searchInput);
+    console.log("searchValue:", searchValue);
+    console.log("전달되는 name 파라미터:", searchInput);
+    console.log("name 파라미터 길이:", searchInput.length);
+  }, [searchInput, searchValue]);
+
+  // usePagination 호출 시 파라미터 확인
+  useEffect(() => {
+    console.log("=== FinalInterview.tsx usePagination 파라미터 ===");
+    console.log("전달되는 name:", searchInput);
+    console.log("전달되는 type:", selectedRole);
+    console.log("전달되는 pageType:", "최종 면접 평가");
+  }, [searchInput, selectedRole]);
 
   // 응답 데이터 로깅
   useEffect(() => {
@@ -70,12 +88,11 @@ const FinalInterview = () => {
     console.log("현재 탭:", activeTab);
     console.log("현재 status:", getStatusFromTab(activeTab));
     console.log("전체 리스트:", entireList);
-    console.log("필터된 리스트:", filteredList);
     console.log("isLoading:", isLoading);
     console.log("totalPages:", totalPages);
     console.log("countData:", countData);
     console.log("=============================");
-  }, [entireList, activeTab, filteredList, isLoading, totalPages, countData]);
+  }, [entireList, activeTab, isLoading, totalPages, countData]);
 
   
   const openModal = () => {
@@ -220,23 +237,31 @@ const FinalInterview = () => {
           <Tab
             categories={["전체", "평가 진행 전", "불합격", "합격"]}
             active={activeTab}
-            onChange={(tab) => {
-              setActiveTab(tab);
-              setCurrentPage(1); // 탭 변경 시 첫 페이지로 이동
-              setSearchInput(""); // 검색 입력값 초기화
-              // 캐시 무효화
-              queryClient.invalidateQueries({ 
-                queryKey: ["pagination", "최종 면접 평가"] 
-              });
-            }}
+                          onChange={(tab) => {
+                setActiveTab(tab);
+                setCurrentPage(1); // 탭 변경 시 첫 페이지로 이동
+                setSearchInput(""); // 검색 입력값 초기화
+                setSearchValue(""); // 검색 입력값 초기화
+                setSelectedRole(null); // 지원 분야 필터 초기화
+                // 캐시 무효화
+                queryClient.invalidateQueries({ 
+                  queryKey: ["pagination", "최종 면접 평가"] 
+                });
+              }}
           />
 
           <FlexBox className="gap-4">
-            <FilterButton checkedList={checkedRoles} onChange={handleFilter} />
+            <FilterButton selectedRole={selectedRole} onChange={handleFilter} />
             <SearchInput
               placeholder="이름을 입력해주세요"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  console.log("Enter 키 입력됨, searchValue:", searchValue);
+                  setSearchInput(searchValue);
+                }
+              }}
             />
           </FlexBox>
         </FlexBox>
@@ -250,7 +275,7 @@ const FinalInterview = () => {
               "면접 일자",
               "최종 평가",
             ]}
-            applications={filteredList}
+            applications={entireList}
             totalPages={totalPages}
             isLoading={isLoading}
             currentPage={currentPage}

--- a/src/types/role.d.ts
+++ b/src/types/role.d.ts
@@ -1,7 +1,7 @@
 export type RoleType =
-  | "웹 프론트"
-  | "백엔드"
-  | "디자인"
-  | "데이터 분석"
-  | "딥러닝"
-  | "앱 프론트";
+  | "WEBFRONTEND"
+  | "BACKEND"
+  | "DESIGN"
+  | "DATAANALYSIS"
+  | "DEEPLEARNING"
+  | "APPFRONTEND";


### PR DESCRIPTION
## 작업 내용
기존의 이름 검색, 분야 필터가 해당 페이지 내에서만 조회되었던 문제를 해결했습니다.
(서류 평가 페이지, 푀종 서류 평가 페이지, 최종 면접 평가 페이지)

<img width="266" height="56" alt="스크린샷 2025-08-10 오후 11 23 53" src="https://github.com/user-attachments/assets/82aa0454-83a7-466b-be53-60702efb752e" />
(아래 결과는 실제 지원서라 캡쳐하지 않았습니다!)

그리고, 페이지 정보를 `type`으로 지정했었는데 지원 분야를`fieldType`-> `type`으로 바꾸면서 페이지 정보를 `pageType`으로 변경했습니다.