### PR TITLE
FEAT : 포트폴리오 다운로드 API 연동

### DIFF
--- a/src/pages/Evaluation/Detail.tsx
+++ b/src/pages/Evaluation/Detail.tsx
@@ -5,7 +5,7 @@ import FlexBox from "@/components/Layout/FlexBox";
 import Body from "@/components/Layout/Body";
 import Tab from "@/components/Tab/Tab";
 import Accordion from "@/components/Accordion/Accordion";
-import { fetchDocumentDetail, getDocumentDetail, fetchResumeQuestions, fetchMemberInfo } from "./api";
+import { fetchDocumentDetail, getDocumentDetail, fetchResumeQuestions, fetchMemberInfo, downloadPortfolio } from "./api";
 import type { Resume, Question } from "@/types/interview";
 import TextArea from "@/components/Input/TextArea";
 import StepCounter from "@/components/StepCounter/StepCounter";
@@ -235,56 +235,43 @@ const Detail = () => {
                       <div>
                         <h4 className="font-semibold text-gray-900 mb-2">포트폴리오</h4>
                         <button 
-                          onClick={() => {
-                            const url = questions.portfolioUrl;
-                            // S3 URL에서 파일명 추출 (UUID 형식)
-                            const fileName = url.split('/').pop() || 'portfolio.pdf';
-                            
-                            // fetch로 파일을 가져와서 강제 다운로드
-                            fetch(url, {
-                              method: 'GET',
-                              headers: {
-                                'Accept': 'application/pdf',
-                              },
-                            })
-                              .then(response => {
-                                if (!response.ok) throw new Error('Network response was not ok');
-                                return response.blob();
-                              })
-                              .then(blob => {
-                                // blob을 다운로드 가능한 형태로 변환
-                                const blobUrl = window.URL.createObjectURL(blob);
-                                const downloadLink = document.createElement('a');
-                                downloadLink.href = blobUrl;
-                                downloadLink.download = fileName;
-                                downloadLink.style.display = 'none';
-                                
-                                // DOM에 추가하고 클릭
-                                document.body.appendChild(downloadLink);
-                                downloadLink.click();
-                                
-                                // 정리
-                                setTimeout(() => {
-                                  document.body.removeChild(downloadLink);
-                                  window.URL.revokeObjectURL(blobUrl);
-                                }, 100);
-                              })
-                              .catch(error => {
-                                console.error('다운로드 실패:', error);
-                                // fallback: 새 창에서 다운로드 시도
-                                const newWindow = window.open(url, '_blank');
-                                if (newWindow) {
-                                  newWindow.document.write(`
-                                    <html>
-                                      <head><title>다운로드 중...</title></head>
-                                      <body>
-                                        <p>파일이 다운로드되지 않았습니다. 
-                                        <a href="${url}" download="${fileName}">여기를 클릭하여 다운로드</a></p>
-                                      </body>
-                                    </html>
-                                  `);
-                                }
-                              });
+                          onClick={async () => {
+                            const resumeId = application?.resumeId;
+                            if (!resumeId) {
+                              setPostMessage("포트폴리오 다운로드에 실패했습니다.");
+                              setIsToastOpen(true);
+                              return;
+                            }
+
+                            try {
+
+                              const blob = await downloadPortfolio(resumeId);
+
+                              // 지원자 이름으로 파일명 생성
+                              const applicantName = applicant?.username || applicant?.name || '지원자';
+                              const fileName = `portfolio_${applicantName}.pdf`;
+                              
+                              // blob을 다운로드 가능한 형태로 변환
+                              const blobUrl = window.URL.createObjectURL(blob);
+                              const downloadLink = document.createElement('a');
+                              downloadLink.href = blobUrl;
+                              downloadLink.download = fileName;
+                              downloadLink.style.display = 'none';
+                              
+                              // DOM에 추가하고 클릭
+                              document.body.appendChild(downloadLink);
+                              downloadLink.click();
+                              
+                              // 정리
+                              setTimeout(() => {
+                                document.body.removeChild(downloadLink);
+                                window.URL.revokeObjectURL(blobUrl);
+                              }, 100);
+                            } catch (error: any) {
+                              console.error('포트폴리오 다운로드 실패:', error);
+                              setPostMessage(`포트폴리오 다운로드에 실패했습니다: ${error.message}`);
+                              setIsToastOpen(true);
+                            }
                           }}
                           className="text-blue-600 hover:text-blue-800 underline break-all cursor-pointer bg-transparent border-none p-0"
                         >

--- a/src/pages/Evaluation/api/index.ts
+++ b/src/pages/Evaluation/api/index.ts
@@ -87,6 +87,31 @@ export const submitFinalEvaluation = async (resumeId: string, status: "PASS" | "
   }
 };
 
+// 포트폴리오 다운로드 API
+export const downloadPortfolio = async (resumeId: string) => {
+  try {
+    const res = await axiosInstance.get(
+      `/v1/manager/resume/portfolio/${resumeId}`,
+      {
+        responseType: 'blob',
+        headers: {
+          'Accept': 'application/octet-stream',
+        },
+      }
+    );
+    
+    if (res.data instanceof Blob) {
+      return res.data;
+    } else {
+      throw new Error('응답이 Blob 형태가 아닙니다.');
+    }
+  } catch (error: any) {
+    console.error("포트폴리오 다운로드 에러:", error);
+    
+    throw error;
+  }
+};
+
 // 지원서 질문 & 답변 정보 API
 export const fetchResumeQuestions = async (resumeId: string) => {
   try {
@@ -97,14 +122,6 @@ export const fetchResumeQuestions = async (resumeId: string) => {
     const res = await axiosInstance.get(
       `/v1/member/resumes/${resumeId}/details`
     );
-    
-    console.log("=== API 응답 결과 ===");
-    console.log("전체 응답:", res.data);
-    console.log("응답 코드:", res.data?.code);
-    console.log("응답 메시지:", res.data?.message);
-    console.log("응답 결과:", res.data?.result);
-    console.log("================================");
-    
     const result = res.data?.result;
     
     // 공통 질문과 파트별 질문을 분리하여 변환


### PR DESCRIPTION
##작업 내용
> 포트폴리오를 미리보기에서 다운로드 방식으로 수정하였습니다.

기존에는 브라우저에 미리보기 방식으로 띄웠으나, 렌더링 시간이 너무 크게 걸려서 미리 보기 없이 파일로 다운로드 하게 수정했습니다. (API 추가)

또한 이름이 `portfolio.pdf`로 고정이 되어있어 지원자 간 포트폴리오 구분이 어려워, `portfolio_${applicantName}.pdf` (portfolio_지원자이름.pdf)로 이름을 자동 설정하여 다운로드 하도록 변경하였습니다.