### PR TITLE
FEAT : 면접 평가 질문 수정

### DIFF
--- a/src/pages/Evaluation/InterviewDetail.tsx
+++ b/src/pages/Evaluation/InterviewDetail.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState, useMemo } from "react";
 import SkeletonAccordion from "@/components/Accordion/Skeleton";
 import { formatKorDate, formatTimeRange } from "@/utils/formatDate";
 import { fetchList } from "@/api/fetchList";
+import { fetchResumeQuestions, downloadPortfolio } from "./api";
 
 const InterviewDetail = () => {
   const navigate = useNavigate();
@@ -34,7 +35,7 @@ const InterviewDetail = () => {
       state: { date, time: timeSlots[newIdx], count }
     });
   };
-  //const { id: date } = useParams();
+
   const { data: applicant } = useQuery<Resume>({
     queryKey: ["setting", "interviewer"],
     queryFn: () => fetchInterviewer("1"),
@@ -49,26 +50,6 @@ const InterviewDetail = () => {
     queryFn: () => fetchList("면접 현황", { date, time }),
     enabled: Boolean(date) && Boolean(time)
   });
-
-  // 공통 질문 데이터 추출
-  const commonQuestions = interviewData?.result?.resumeList?.[0]?.common?.[0]?.commonQuestions ?? [];
-  const handleActiveNames = (name: string) => {
-    setActiveLabels((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(name)) {
-        newSet.delete(name);
-      } else {
-        newSet.add(name);
-      }
-      return newSet;
-    });
-  };
-  // 파트별 질문 데이터 추출
-  const partQuestions = interviewData?.result?.resumeList?.[0]?.specific?.[0]?.specificQuestions ?? [];
-
-
-  // 지원자 정보 추출
-  const memberInfo = interviewData?.result?.resumeList?.[0]?.resumeMemberInfoDto;
 
   // 지원서 목록 추출
   const resumeList = interviewData?.result?.resumeList ?? [];
@@ -173,71 +154,229 @@ const InterviewDetail = () => {
             <article key={articleIdx} className="w-[1344px] mx-auto flex gap-4 text-gray-900 pb-12">
               {selectedResumes.slice(articleIdx * 2, articleIdx * 2 + 2).map((resume: any, idx: number) => {
                 const memberInfo = resume.resumeMemberInfoDto;
-                const partQuestions = resume.specific?.[0]?.specificQuestions ?? [];
-                const commonQuestions = resume.common?.[0]?.commonQuestions ?? [];
                 return (
-                  <div key={resume.resumeId} className="flex flex-col gap-4 rounded-lg border border-gray-300 bg-white w-1/2 px-6 py-4">
-                    <FlexBox className="gap-2">
-                      <h2 className="font-bold text-xl">{memberInfo?.username ?? '-'}</h2>
-                      <Chip title={memberInfo?.field as any ?? '-'} />
-                    </FlexBox>
-                    <div className="grid grid-cols-2 gap-4">
-                      <FlexBox className="gap-4">
-                        <label htmlFor="gender" className="text-gray-500">성별</label>
-                        <p id="gender">{memberInfo?.sex ?? '-'}</p>
-                      </FlexBox>
-                      <FlexBox className="gap-4">
-                        <label htmlFor="school" className="text-gray-500">학교</label>
-                        <p id="school">{memberInfo?.univ ?? '-'}</p>
-                      </FlexBox>
-                      <FlexBox className="gap-4">
-                        <label htmlFor="birth" className="text-gray-500">생년월일</label>
-                        <p id="birth">{memberInfo?.birthday ?? '-'}</p>
-                      </FlexBox>
-                      <FlexBox className="gap-4">
-                        <label htmlFor="major" className="text-gray-500">전공</label>
-                        <p id="major">{memberInfo?.major ?? '-'}</p>
-                      </FlexBox>
-                    </div>
-                    <Tab
-                      categories={["파트별 질문", "공통 질문"]}
-                      active={activeTab}
-                      onChange={setActiveTab}
-                      className="pt-8"
-                    />
-                    <FlexBox direction="col" className="gap-8 overflow-y-scroll py-6">
-                      {activeTab === "공통 질문" &&
-                        commonQuestions.map((q: any) => (
-                          <Accordion key={q.id} title={q.question} className="w-full">
-                            <TextArea
-                              value={q.answer ?? "미답변"}
-                              readOnly={true}
-                              className="w-full h-full"
-                            />
-                          </Accordion>
-                        ))}
-                      {activeTab === "파트별 질문" &&
-                        partQuestions.map((q: any, index: number) => (
-                          <Accordion
-                            key={q.id}
-                            title={q.question}
-                            className="w-full"
-                          >
-                            <TextArea
-                              value={q.answer ?? "미답변"}
-                              readOnly={true}
-                              className="w-full h-full"
-                            />
-                          </Accordion>
-                        ))}
-                    </FlexBox>
-                  </div>
+                  <ResumeCard 
+                    key={resume.resumeId} 
+                    resume={resume} 
+                    memberInfo={memberInfo}
+                  />
                 );
               })}
             </article>
           ));
         })()}
       </Body>
+    </div>
+  );
+};
+
+// 지원서 카드 컴포넌트
+const ResumeCard = ({ resume, memberInfo }: any) => {
+  const [questions, setQuestions] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState("파트별 질문");
+
+  // 지원서 질문 정보 조회
+  const { data: resumeQuestions, isLoading: questionsLoading } = useQuery({
+    queryKey: ["resume-questions", resume.resumeId],
+    queryFn: () => fetchResumeQuestions(resume.resumeId),
+    enabled: !!resume.resumeId,
+  });
+
+  useEffect(() => {
+    if (resumeQuestions?.result) {
+      setQuestions(resumeQuestions.result);
+    }
+  }, [resumeQuestions]);
+
+  const commonQuestions = questions?.commonQuestions || [];
+  const partQuestions = questions?.partQuestions || [];
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border border-gray-300 bg-white w-1/2 px-6 py-4">
+      <FlexBox className="gap-2">
+        <h2 className="font-bold text-xl">{memberInfo?.username ?? '-'}</h2>
+        <Chip title={memberInfo?.field as any ?? '-'} />
+      </FlexBox>
+      <div className="grid grid-cols-2 gap-4">
+        <FlexBox className="gap-4">
+          <label htmlFor="gender" className="text-gray-500">성별</label>
+          <p id="gender">{memberInfo?.sex === "MALE" ? "남자" : memberInfo?.sex === "FEMALE" ? "여자" : memberInfo?.sex ?? '-'}</p>
+        </FlexBox>
+        <FlexBox className="gap-4">
+          <label htmlFor="school" className="text-gray-500">학교</label>
+          <p id="school">{memberInfo?.univ ?? memberInfo?.school ?? '-'}</p>
+        </FlexBox>
+        <FlexBox className="gap-4">
+          <label htmlFor="birth" className="text-gray-500">생년월일</label>
+          <p id="birth">{memberInfo?.birthday ?? '-'}</p>
+        </FlexBox>
+        <FlexBox className="gap-4">
+          <label htmlFor="major" className="text-gray-500">전공</label>
+          <p id="major">{memberInfo?.major ?? '-'}</p>
+        </FlexBox>
+      </div>
+      <Tab
+        categories={["파트별 질문", "공통 질문"]}
+        active={activeTab}
+        onChange={setActiveTab}
+        className="pt-8"
+      />
+      <FlexBox direction="col" className="gap-8 overflow-y-scroll py-6">
+        {activeTab === "공통 질문" && (
+          <>
+            {questionsLoading ? (
+              Array.from({ length: 3 }).map((_, index) => (
+                <SkeletonAccordion key={index} />
+              ))
+            ) : commonQuestions.length > 0 ? (
+              <>
+                {commonQuestions
+                  .sort((a: any, b: any) => a.id - b.id)
+                  .map((q: any) => (
+                    <Accordion key={q.id} title={q.question} className="w-full">
+                      <TextArea
+                        value={q.answer ?? "미답변"}
+                        readOnly={true}
+                        className="w-full h-full"
+                      />
+                    </Accordion>
+                  ))}
+                <Accordion
+                  title="아래의 목록 중 소유하신 것이 있다면 자유롭게 첨부해주세요 :)"
+                  className="w-full"
+                >
+                  <div className="space-y-4">
+                    {questions?.githubUrl && (
+                      <div>
+                        <h4 className="font-semibold text-gray-900 mb-2">GitHub</h4>
+                        <a 
+                          href={questions.githubUrl} 
+                          target="_blank" 
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:text-blue-800 underline break-all"
+                        >
+                          {questions.githubUrl}
+                        </a>
+                      </div>
+                    )}
+                    {questions?.blogUrl && (
+                      <div>
+                        <h4 className="font-semibold text-gray-900 mb-2">블로그</h4>
+                        <a 
+                          href={questions.blogUrl} 
+                          target="_blank" 
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:text-blue-800 underline break-all"
+                        >
+                          {questions.blogUrl}
+                        </a>
+                      </div>
+                    )}
+                    {questions?.portfolioUrl && (
+                      <div>
+                        <h4 className="font-semibold text-gray-900 mb-2">포트폴리오</h4>
+                        <button 
+                          onClick={async () => {
+                            try {
+                              const blob = await downloadPortfolio(resume.resumeId);
+                              
+                              // 지원자 이름으로 파일명 생성
+                              const applicantName = memberInfo?.username || memberInfo?.name || '지원자';
+                              const fileName = `portfolio_${applicantName}.pdf`;
+                              
+                              // blob을 다운로드 가능한 형태로 변환
+                              const blobUrl = window.URL.createObjectURL(blob);
+                              const downloadLink = document.createElement('a');
+                              downloadLink.href = blobUrl;
+                              downloadLink.download = fileName;
+                              downloadLink.style.display = 'none';
+                              
+                              // DOM에 추가하고 클릭
+                              document.body.appendChild(downloadLink);
+                              downloadLink.click();
+                              
+                              // 정리
+                              setTimeout(() => {
+                                document.body.removeChild(downloadLink);
+                                window.URL.revokeObjectURL(blobUrl);
+                              }, 100);
+                            } catch (error: any) {
+                              console.error('포트폴리오 다운로드 실패:', error);
+                            }
+                          }}
+                          className="text-blue-600 hover:text-blue-800 underline break-all cursor-pointer bg-transparent border-none p-0"
+                        >
+                          포트폴리오 다운로드
+                        </button>
+                      </div>
+                    )}
+                    {!questions?.githubUrl && !questions?.blogUrl && !questions?.portfolioUrl && (
+                      <p className="text-gray-500">첨부된 링크가 없습니다.</p>
+                    )}
+                  </div>
+                </Accordion>
+              </>
+            ) : (
+              <div className="flex flex-col justify-center items-center gap-4 p-4 text-gray-700 w-full h-full text-center">
+                <Icon type="Alert" size={28} />
+                <p>공통 질문이 없습니다.</p>
+              </div>
+            )}
+          </>
+        )}
+        {activeTab === "파트별 질문" && (
+          <>
+            {questionsLoading ? (
+              Array.from({ length: 3 }).map((_, index) => (
+                <SkeletonAccordion key={index} />
+              ))
+            ) : partQuestions.length > 0 ? (
+              partQuestions
+                .sort((a: any, b: any) => a.id - b.id)
+                .map((q: any, index: number) => (
+                  <Accordion
+                    key={q.id}
+                    title={q.question}
+                    className="w-full"
+                  >
+                    {index === 0 && questions?.languageLevels && questions.languageLevels.length > 0 ? (
+                      <div className="space-y-4">
+                        {/* 언어 레벨 정보 */}
+                        <div>
+                          <h4 className="font-semibold text-gray-900 mb-2">언어 레벨</h4>
+                          <div className="space-y-4">
+                            {questions.languageLevels.map((lang: any, langIndex: number) => (
+                              <StepCounter
+                                key={langIndex}
+                                title={lang.language}
+                                currentStep={lang.level}
+                                setCurrentStep={() => {}}
+                                maxStep={5}
+                                stepLabels={["입문", "초급", "중급", "고급", "전문가"]}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <TextArea
+                        value={q.answer ?? "미답변"}
+                        readOnly={true}
+                        className="w-full min-h-[250px] h-full"
+                      />
+                    )}
+                  </Accordion>
+                ))
+            ) : (
+              <div className="flex flex-col justify-center items-center gap-4 p-4 text-gray-700 w-full h-full text-center">
+                <Icon type="Alert" size={28} />
+                <p>파트별 질문이 없습니다.</p>
+              </div>
+            )}
+          </>
+        )}
+      </FlexBox>
     </div>
   );
 };


### PR DESCRIPTION
면접 평가 페이지의 면접 질문&답변 부분 수정
1. 질문 데이터의 순서가 랜덤하게 뜨는 문제 처리
``` {commonQuestions
                  .sort((a: any, b: any) => a.id - b.id)
                  .map((q: any) => (
```


2. 메인 프로그래밍 실력(디아니 파트일 경우, 사용가능한 툴 및 실력)의 답변이 안뜨는 문제 처리
-> 서류 평가 페이지와 동일한 API 사용

```<div className="space-y-4">
                        {/* 언어 레벨 정보 */}
                        <div>
                          <h4 className="font-semibold text-gray-900 mb-2">언어 레벨</h4>
                          <div className="space-y-4">
                            {questions.languageLevels.map((lang: any, langIndex: number) => (
                              <StepCounter
                                key={langIndex}
                                title={lang.language}
                                currentStep={lang.level}
                                setCurrentStep={() => {}}
                                maxStep={5}
                                stepLabels={["입문", "초급", "중급", "고급", "전문가"]}
                              />
                            ))}
                          </div>
                        </div>
                      </div>
```

3. 포트폴리오 보기 -> 포트폴리오 다운로드 기능 수정
4. 면접자별로 Tab 이 변하지 않는 문제 수정(Tab 컴포넌트 공유 수정)

```// 지원서 카드 컴포넌트
const ResumeCard = ({ resume, memberInfo }: any) => {
  const [questions, setQuestions] = useState<any>(null);
  const [isLoading, setIsLoading] = useState(false);
  const [activeTab, setActiveTab] = useState("파트별 질문");
``` 

(ResumeCard 컴포넌트에서 activeTab과 setActiveTab을 props로 받지 않고 각각의 컴포넌트 내부에서 useState로 관리)
