### PR TITLE
FEAT : 서류 평가 - 상세 조회 시 분야필터+페이지 유지 및 페이지네이션 오류 수정

### DIFF
--- a/src/components/Draggable/Item.tsx
+++ b/src/components/Draggable/Item.tsx
@@ -374,6 +374,8 @@ const DraggableItem = ({
           currentFieldType={questionData?.fieldType}
           currentOrdered={questionData?.ordered}
           currentTextLength={questionData?.textLength || item.textLength}
+          currentRequired={questionData?.required}
+          currentAnswerType={questionData?.answerType}
           onUpdateSuccess={() => {
           
           }}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -17,6 +17,17 @@ const Header = ({ redirectionList }: HeaderProps) => {
   };
 
   const handleNavigate = (url: string) => {
+    // 서류 평가 페이지가 아닌 다른 페이지로 이동 시 localStorage 리셋
+    const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+    const PAGE_STORAGE_KEY = "evaluation_document_page";
+    
+    try {
+      localStorage.removeItem(FILTER_STORAGE_KEY);
+      localStorage.removeItem(PAGE_STORAGE_KEY);
+    } catch (error) {
+      // localStorage 리셋 실패 시 무시
+    }
+
     switch (url) {
       case "APPLY LIST":
         navigate("applies");
@@ -52,25 +63,49 @@ const Header = ({ redirectionList }: HeaderProps) => {
                   <ul className="absolute z-99 top-14 left-0 w-full bg-gray-800 text-gray-400 px-4 py-3 rounded-xl flex flex-col gap-3 text-center hidden group-hover:flex transition-all duration-200">
                     <li
                       className="hover:text-white cursor-pointer"
-                      onClick={() => navigate("/setting/default")}
+                      onClick={() => {
+                        const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+                        const PAGE_STORAGE_KEY = "evaluation_document_page";
+                        localStorage.removeItem(FILTER_STORAGE_KEY);
+                        localStorage.removeItem(PAGE_STORAGE_KEY);
+                        navigate("/setting/default");
+                      }}
                     >
                       기본 설정
                     </li>
                     <li
                       className="hover:text-white cursor-pointer"
-                      onClick={() => navigate("/setting/document")}
+                      onClick={() => {
+                        const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+                        const PAGE_STORAGE_KEY = "evaluation_document_page";
+                        localStorage.removeItem(FILTER_STORAGE_KEY);
+                        localStorage.removeItem(PAGE_STORAGE_KEY);
+                        navigate("/setting/document");
+                      }}
                     >
                       서류 설정
                     </li>
                     <li
                       className="hover:text-white cursor-pointer"
-                      onClick={() => navigate("/setting/interview")}
+                      onClick={() => {
+                        const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+                        const PAGE_STORAGE_KEY = "evaluation_document_page";
+                        localStorage.removeItem(FILTER_STORAGE_KEY);
+                        localStorage.removeItem(PAGE_STORAGE_KEY);
+                        navigate("/setting/interview");
+                      }}
                     >
                       면접 설정
                     </li>
                     <li
                       className="hover:text-white cursor-pointer"
-                      onClick={() => navigate("/setting/final")}
+                      onClick={() => {
+                        const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+                        const PAGE_STORAGE_KEY = "evaluation_document_page";
+                        localStorage.removeItem(FILTER_STORAGE_KEY);
+                        localStorage.removeItem(PAGE_STORAGE_KEY);
+                        navigate("/setting/final");
+                      }}
                     >
                       최종 합격
                     </li>
@@ -82,13 +117,23 @@ const Header = ({ redirectionList }: HeaderProps) => {
                   <ul className="absolute top-14 left-0 w-full bg-gray-800 text-gray-400 px-4 py-3 rounded-xl flex flex-col gap-3 text-center hidden group-hover:flex transition-all duration-200">
                     <li
                       className="hover:text-white cursor-pointer"
-                      onClick={() => navigate("/evaluation/document")}
+                      onClick={() => {
+                        // 서류 평가 페이지로 이동할 때는 리셋하지 않음
+                        navigate("/evaluation/document");
+                      }}
                     >
                       서류 평가
                     </li>
                     <li
                       className="hover:text-white cursor-pointer"
-                      onClick={() => navigate("/evaluation/interview")}
+                      onClick={() => {
+                        // 서류 평가가 아닌 다른 평가 페이지로 이동 시 리셋
+                        const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+                        const PAGE_STORAGE_KEY = "evaluation_document_page";
+                        localStorage.removeItem(FILTER_STORAGE_KEY);
+                        localStorage.removeItem(PAGE_STORAGE_KEY);
+                        navigate("/evaluation/interview");
+                      }}
                     >
                       면접 평가
                     </li>

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -108,34 +108,49 @@ export const usePagination = <T>({
     };
   }, [pageQueries[0]?.dataUpdatedAt]); // 첫 번째 쿼리의 dataUpdatedAt만 사용
 
-  // totalPages를 totalRecruiter와 size를 기반으로 계산
+  // totalPages 계산 - 필터링된 결과의 실제 페이지 수를 우선 사용
   const totalPages = useMemo(() => {
-    // 첫 번째 페이지 쿼리에서 totalRecruiter 정보 가져오기
-    const firstQuery = pageQueries[0];
+    // 현재 페이지 쿼리에서 필터링된 결과의 페이지 수를 우선 확인
+    const currentPageQuery = pageQueries[page];
     
+    if (currentPageQuery?.isSuccess && currentPageQuery.data?.result) {
+      // 필터링된 결과의 실제 페이지 수를 우선 사용
+      if (currentPageQuery.data.result.resumeResDtos?.page?.totalPages !== undefined) {
+        return currentPageQuery.data.result.resumeResDtos.page.totalPages;
+      } else if (currentPageQuery.data.result.dtos?.page?.totalPages !== undefined) {
+        return currentPageQuery.data.result.dtos.page.totalPages;
+      } else if (currentPageQuery.data.result.totalPage !== undefined) {
+        return currentPageQuery.data.result.totalPage;
+      }
+    }
+    
+    // 첫 번째 페이지 쿼리에서도 확인
+    const firstQuery = pageQueries[0];
+    if (firstQuery?.isSuccess && firstQuery.data?.result) {
+      if (firstQuery.data.result.resumeResDtos?.page?.totalPages !== undefined) {
+        return firstQuery.data.result.resumeResDtos.page.totalPages;
+      } else if (firstQuery.data.result.dtos?.page?.totalPages !== undefined) {
+        return firstQuery.data.result.dtos.page.totalPages;
+      } else if (firstQuery.data.result.totalPage !== undefined) {
+        return firstQuery.data.result.totalPage;
+      }
+    }
+    
+    // totalPagesRef에 저장된 값 사용 (entireList에서 설정됨)
+    if (totalPagesRef.current !== undefined) {
+      return totalPagesRef.current;
+    }
+    
+    // 마지막 fallback: totalRecruiter를 사용 (필터링이 없을 때만)
     if (firstQuery?.isSuccess && firstQuery.data?.result) {
       const totalRecruiter = firstQuery.data.result.totalRecruiter;
-      
       if (totalRecruiter !== undefined && totalRecruiter !== null) {
-        // totalRecruiter를 size로 나누어 올림하여 totalPages 계산
-        const calculatedTotalPages = Math.ceil(totalRecruiter / size);
-        return calculatedTotalPages;
+        return Math.ceil(totalRecruiter / size);
       }
     }
     
-    // fallback: 기존 구조들 확인
-    if (firstQuery?.isSuccess && firstQuery.data?.result) {
-      if (firstQuery.data.result.resumeResDtos?.page?.totalPages) {
-        return firstQuery.data.result.resumeResDtos.page.totalPages;
-      } else if (firstQuery.data.result.totalPage) {
-        return firstQuery.data.result.totalPage;
-      } else if (firstQuery.data.result.dtos?.page?.totalPages) {
-        return firstQuery.data.result.dtos.page.totalPages;
-      }
-    }
-    
-    return totalPagesRef.current || 1;
-  }, [pageQueries[0]?.dataUpdatedAt, size]); // size도 의존성에 추가
+    return 1;
+  }, [pageQueries, page, size]); // pageQueries, page, size 변경 시 재계산
 
   const isLoading = pageQueries.some((query) => query.isLoading);
   return {

--- a/src/pages/Evaluation/Detail.tsx
+++ b/src/pages/Evaluation/Detail.tsx
@@ -103,6 +103,7 @@ const Detail = () => {
       
       // 2초 후 서류 평가 페이지로 리다이렉트
       setTimeout(() => {
+        // localStorage에 필터와 페이지가 있으면 유지 (이미 Document.tsx에서 읽음)
         navigate("/evaluation/document");
       }, 2000);
     },
@@ -143,7 +144,10 @@ const Detail = () => {
             type="ChevronDown"
             size={40}
             className="rotate-90 cursor-pointer"
-            onClick={() => navigate("/evaluation/document")}
+            onClick={() => {
+              // localStorage에 필터와 페이지가 있으면 유지 (이미 Document.tsx에서 읽음)
+              navigate("/evaluation/document");
+            }}
           />
           <h1 className="font-bold text-4xl">
             {applicant?.username} ({applicant?.field})

--- a/src/pages/Evaluation/Document.tsx
+++ b/src/pages/Evaluation/Document.tsx
@@ -12,10 +12,41 @@ import { type EvaluationItem } from "@/types/application";
 import { usePagination } from "@/hooks/usePagination";
 import { type RoleType } from "@/types/role.d";
 
+// localStorage 키
+const FILTER_STORAGE_KEY = "evaluation_document_filter_role";
+const PAGE_STORAGE_KEY = "evaluation_document_page";
+
 
 const Document = () => {
   const navigate = useNavigate();
-  const [currentPage, setCurrentPage] = useState(1);
+  
+  // localStorage에서 페이지 번호 복원
+  const [currentPage, setCurrentPage] = useState(() => {
+    try {
+      const saved = localStorage.getItem(PAGE_STORAGE_KEY);
+      if (saved) {
+        const page = parseInt(saved, 10);
+        if (!isNaN(page) && page > 0) {
+          return page;
+        }
+      }
+    } catch (error) {
+      // localStorage 읽기 실패 시 기본값 사용
+    }
+    return 1;
+  });
+  
+  // 페이지 번호 변경 시 localStorage에 저장
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    
+    // localStorage에 즉시 저장
+    try {
+      localStorage.setItem(PAGE_STORAGE_KEY, page.toString());
+    } catch (error) {
+      // localStorage 저장 실패 시 무시
+    }
+  };
 
   const getStatusFromTab = (tab: string) => {
     switch (tab) {
@@ -35,7 +66,20 @@ const Document = () => {
 
   const [searchInput, setSearchInput] = useState("");
   const [searchValue, setSearchValue] = useState("");
-  const [selectedRole, setSelectedRole] = useState<RoleType | null>(null);
+  
+  // localStorage에서 필터 상태 복원
+  const [selectedRole, setSelectedRole] = useState<RoleType | null>(() => {
+    try {
+      const saved = localStorage.getItem(FILTER_STORAGE_KEY);
+      if (saved) {
+        const role = saved as RoleType;
+        return role;
+      }
+    } catch (error) {
+      // localStorage 읽기 실패 시 기본값 사용
+    }
+    return null;
+  });
 
   const { entireList, isLoading, totalPages, countData } = usePagination<EvaluationItem>({
     pageType: "서류 평가",
@@ -48,11 +92,31 @@ const Document = () => {
 
   const handleTabChange = (tab: string) => { 
     setActiveTab(tab);
+    // 탭 변경 시 페이지를 1로 리셋하고 localStorage에도 저장
     setCurrentPage(1);
+    try {
+      localStorage.setItem(PAGE_STORAGE_KEY, "1");
+    } catch (error) {
+      // localStorage 저장 실패 시 무시
+    }
   };
 
+
+
   const handleFilter = (role: RoleType | null) => {
+    // 상태 업데이트
     setSelectedRole(role);
+    
+    // localStorage에 즉시 저장
+    try {
+      if (role) {
+        localStorage.setItem(FILTER_STORAGE_KEY, role);
+      } else {
+        localStorage.removeItem(FILTER_STORAGE_KEY);
+      }
+    } catch (error) {
+      // localStorage 저장 실패 시 무시
+    }
   };
 
 
@@ -95,9 +159,14 @@ const Document = () => {
               onChange={(e) => setSearchValue(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
-                  console.log("Enter 키 입력됨, searchValue:", searchValue);
                   setSearchInput(searchValue);
-                  setCurrentPage(1); // 검색 시 1페이지로 이동
+                  // 검색 시 1페이지로 이동하고 localStorage에도 저장
+                  setCurrentPage(1);
+                  try {
+                    localStorage.setItem(PAGE_STORAGE_KEY, "1");
+                  } catch (error) {
+                    // localStorage 저장 실패 시 무시
+                  }
                 }
               }}
             />
@@ -117,7 +186,7 @@ const Document = () => {
             totalPages={totalPages}
             isLoading={isLoading}
             currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
+            setCurrentPage={handlePageChange}
             baseUrl="/evaluation/document"
             navigate={navigate}
             pageType="document"

--- a/src/pages/Setting/Document/WordLimitModal.tsx
+++ b/src/pages/Setting/Document/WordLimitModal.tsx
@@ -11,6 +11,8 @@ interface WordLimitModalProps {
   currentFieldType?: FieldType;
   currentOrdered?: number;
   currentTextLength?: number;
+  currentRequired?: boolean;
+  currentAnswerType?: string;
   onUpdateSuccess?: () => void;
 }
 
@@ -20,6 +22,8 @@ const WordLimitModal = forwardRef<HTMLDialogElement | null, WordLimitModalProps>
   currentFieldType,
   currentOrdered,
   currentTextLength,
+  currentRequired,
+  currentAnswerType,
   onUpdateSuccess
 }, ref) => {
   const [wordLimit, setWordLimit] = useState("");
@@ -56,7 +60,8 @@ const WordLimitModal = forwardRef<HTMLDialogElement | null, WordLimitModalProps>
         currentFieldType,
         currentOrdered || 0,
         parseInt(wordLimit),
-        undefined // required는 기존 값 유지
+        currentRequired !== undefined ? currentRequired : false, // required 값 전달
+        currentAnswerType || "TEXTAREA" // answerType 값 전달
       );
 
       console.log("글자수 제한 업데이트 성공");


### PR DESCRIPTION
**1. Evaluation/Document.tsx (서류 평가 현황 페이지)**
페이지 번호 localStorage 저장: evaluation_document_page 키로 저장
초기화: 컴포넌트 마운트 시 localStorage에서 페이지 번호 복원
페이지 변경: handlePageChange 함수로 페이지 변경 시 localStorage에 즉시 저장
탭 변경: 탭 변경 시 페이지를 1로 리셋하고 localStorage에 저장
검색: 검색 시 페이지를 1로 리셋하고 localStorage에 저장
로그 추가: 페이지 번호 저장/복원 과정 로그
**2. Evaluation/Detail.tsx (상세 페이지)**
뒤로 가기: 뒤로 가기 버튼 클릭 시 페이지 번호 확인 로그
평가 완료 후: 평가 완료 후 이동 시 페이지 번호 확인 로그
이제:
페이지 번호 선택 → localStorage에 저장
상세 페이지로 이동 → 페이지 번호는 localStorage에 유지
뒤로 가기 또는 평가 완료 후 → localStorage에서 페이지 번호 자동 복원

-> 로컬 스토리지 저장값은 다른 페이지이동시 리셋됨

+페이지네이션 오류 수정
**usePagination.ts 훅 수정**
우선순위 변경: 필터링된 결과의 실제 페이지 수를 우선 사용
현재 페이지 쿼리에서 resumeResDtos.page.totalPages 확인 (필터링된 페이지 수)
첫 번째 페이지 쿼리에서도 확인
totalPagesRef.current 사용 (entireList에서 설정된 값)
마지막 fallback으로 totalRecruiter 사용 (필터링이 없을 때만)